### PR TITLE
ethereum-workitem: Remove redundant parameters

### DIFF
--- a/ethereum-workitem/src/main/java/org/jbpm/process/workitem/ethereum/EthereumUtils.java
+++ b/ethereum-workitem/src/main/java/org/jbpm/process/workitem/ethereum/EthereumUtils.java
@@ -347,11 +347,6 @@ public class EthereumUtils {
                                             List<TypeReference<?>> indexedParameters,
                                             List<TypeReference<?>> nonIndexedParameters,
                                             String eventReturnType,
-                                            KieSession kieSession,
-                                            String signalName,
-                                            boolean doAbortOnUpdate,
-                                            WorkItemManager workItemManager,
-                                            WorkItem workItem,
                                             rx.functions.Action1 action1) {
 
         Event event = new Event(contractEventName,


### PR DESCRIPTION
Hi, @tsurdilo,

I noticed the redundant parameters when doing PR review.