### PR TITLE
Use <target> instead of deprecated <tasks> in antrun plugin config

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -76,11 +76,11 @@
             <id>delete repo resources</id>
             <phase>package</phase>
             <configuration>
-              <tasks>
+              <target>
                 <delete>
                   <fileset dir="${project.build.directory}/${project.artifactId}-${project.version}" includes="repo*.html" />
                 </delete>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>


### PR DESCRIPTION
Fixes the warning
"[WARNING] Parameter tasks is deprecated, use target instead"

See maven-antrun-plugin [docs](http://maven.apache.org/plugins/maven-antrun-plugin/run-mojo.html#tasks)