### PR TITLE
Don't use deprecated variable names

### DIFF
--- a/repository-springboot/pom.xml
+++ b/repository-springboot/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <version.org.springboot>1.5.10.RELEASE</version.org.springboot>
-    <heroku.appName>${artifactId}</heroku.appName>
+    <heroku.appName>${project.artifactId}</heroku.appName>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Fixes build warning:
`[WARNING] The expression ${artifactId} is deprecated. Please use ${project.artifactId} instead.`
@tsurdilo please check and merge.