### PR TITLE
JBPM-8417 - Add Insert/Update/Delete query capability to ExecuteSqlWorkItemHandler

### DIFF
--- a/execute-sql-workitem/src/main/java/org/jbpm/process/workitem/executesql/ExecuteSqlWorkItemHandler.java
+++ b/execute-sql-workitem/src/main/java/org/jbpm/process/workitem/executesql/ExecuteSqlWorkItemHandler.java
@@ -111,10 +111,15 @@ public class ExecuteSqlWorkItemHandler extends AbstractLogOrThrowWorkItemHandler
                 connection = ds.getConnection();
                 statement = connection.prepareStatement(sqlStatement);
                 statement.setMaxRows(maxResults);
-                resultSet = statement.executeQuery();
 
-                results.put(RESULT,
+		boolean containsResultSet = statement.execute();
+		if(containsResultSet){
+                	resultSet = statement.getResultSet();
+                	results.put(RESULT,
                             processResults(resultSet));
+		}else{
+			results.put(RESULT,statement.getUpdateCount());
+		}
                 workItemManager.completeWorkItem(workItem.getId(),
                                                  results);
             } finally {

--- a/execute-sql-workitem/src/main/java/org/jbpm/process/workitem/executesql/ExecuteSqlWorkItemHandler.java
+++ b/execute-sql-workitem/src/main/java/org/jbpm/process/workitem/executesql/ExecuteSqlWorkItemHandler.java
@@ -115,13 +115,11 @@ public class ExecuteSqlWorkItemHandler extends AbstractLogOrThrowWorkItemHandler
 		boolean containsResultSet = statement.execute();
 		if(containsResultSet){
                 	resultSet = statement.getResultSet();
-                	results.put(RESULT,
-                            processResults(resultSet));
+                	results.put(RESULT,processResults(resultSet));
 		}else{
 			results.put(RESULT,statement.getUpdateCount());
 		}
-                workItemManager.completeWorkItem(workItem.getId(),
-                                                 results);
+                workItemManager.completeWorkItem(workItem.getId(),results);
             } finally {
                 try {
                     if (resultSet != null) {

--- a/execute-sql-workitem/src/test/java/org/jbpm/process/workitem/executesql/ExecuteSqlWorkItemHandlerTest.java
+++ b/execute-sql-workitem/src/test/java/org/jbpm/process/workitem/executesql/ExecuteSqlWorkItemHandlerTest.java
@@ -125,7 +125,28 @@ public class ExecuteSqlWorkItemHandlerTest {
         assertNotNull(resultLines);
         assertEquals(0,
                      resultLines.size());
+
     }
+
+    @Test
+    public void testUpdate() throws Exception {
+        TestWorkItemManager manager = new TestWorkItemManager();
+        WorkItemImpl workItem = new WorkItemImpl();
+        workItem.setParameter("SQLStatement",
+                              "update Person set age=4 where id = 3");
+        ExecuteSqlWorkItemHandler handler = new ExecuteSqlWorkItemHandler(DS_NAME);
+        handler.executeWorkItem(workItem,
+                                manager);
+        assertNotNull(manager.getResults());
+        assertEquals(1,
+                     manager.getResults().size());
+        assertTrue(manager.getResults().containsKey(workItem.getId()));
+
+        int changes = (int) manager.getResults().get(workItem.getId()).get("Result");
+        assertEquals(1,changes);
+
+    }
+
 
     private static void insertData() throws Exception {
         DataSource ds = InitialContext.doLookup(DS_NAME);

--- a/execute-sql-workitem/src/test/java/org/jbpm/process/workitem/executesql/ExecuteSqlWorkItemHandlerTest.java
+++ b/execute-sql-workitem/src/test/java/org/jbpm/process/workitem/executesql/ExecuteSqlWorkItemHandlerTest.java
@@ -125,7 +125,6 @@ public class ExecuteSqlWorkItemHandlerTest {
         assertNotNull(resultLines);
         assertEquals(0,
                      resultLines.size());
-
     }
 
     @Test
@@ -135,11 +134,9 @@ public class ExecuteSqlWorkItemHandlerTest {
         workItem.setParameter("SQLStatement",
                               "update Person set age=4 where id = 3");
         ExecuteSqlWorkItemHandler handler = new ExecuteSqlWorkItemHandler(DS_NAME);
-        handler.executeWorkItem(workItem,
-                                manager);
+        handler.executeWorkItem(workItem,manager);
         assertNotNull(manager.getResults());
-        assertEquals(1,
-                     manager.getResults().size());
+        assertEquals(1,manager.getResults().size());
         assertTrue(manager.getResults().containsKey(workItem.getId()));
 
         int changes = (int) manager.getResults().get(workItem.getId()).get("Result");


### PR DESCRIPTION
"executeQuery" doesn't allow querys that could change the Database (Insert,Update...)
I changed it for "execute" and added a test for that case.