### PR TITLE
JBPM-8398 - Kafka WIH org.apache.kafka.common.serialization.StringSerializer could not be found

### DIFF
--- a/kafka-workitem/src/main/java/org/jbpm/process/workitem/kafka/KafkaWorkItemHandler.java
+++ b/kafka-workitem/src/main/java/org/jbpm/process/workitem/kafka/KafkaWorkItemHandler.java
@@ -78,7 +78,7 @@ public class KafkaWorkItemHandler extends AbstractLogOrThrowWorkItemHandler impl
                                 String clientId,
                                 String keySerializerClass,
                                 String valueSerializerClass) {
-        Thread.currentThread().setContextClassLoader(null);
+        
             
         Properties config = new Properties();
         config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,

--- a/kafka-workitem/src/main/java/org/jbpm/process/workitem/kafka/KafkaWorkItemHandler.java
+++ b/kafka-workitem/src/main/java/org/jbpm/process/workitem/kafka/KafkaWorkItemHandler.java
@@ -78,6 +78,8 @@ public class KafkaWorkItemHandler extends AbstractLogOrThrowWorkItemHandler impl
                                 String clientId,
                                 String keySerializerClass,
                                 String valueSerializerClass) {
+        Thread.currentThread().setContextClassLoader(null);
+            
         Properties config = new Properties();
         config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
                    bootstrapServers);

--- a/kafka-workitem/src/main/java/org/jbpm/process/workitem/kafka/KafkaWorkItemHandler.java
+++ b/kafka-workitem/src/main/java/org/jbpm/process/workitem/kafka/KafkaWorkItemHandler.java
@@ -78,7 +78,7 @@ public class KafkaWorkItemHandler extends AbstractLogOrThrowWorkItemHandler impl
                                 String clientId,
                                 String keySerializerClass,
                                 String valueSerializerClass) {
-        
+        Thread.currentThread().setContextClassLoader(null);
             
         Properties config = new Properties();
         config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,


### PR DESCRIPTION
I'm fixing a bug that I got on workbench to use this work item handler, happened on both 7.19 and 7.20 version of the work item handler.
Workbench version 7.19
More details on the jira JBPM-8398
