### PR TITLE
Update newInstance creation for Java 11

### DIFF
--- a/transform-workitem/src/main/java/org/jbpm/process/workitem/transform/TransformWorkItemHandler.java
+++ b/transform-workitem/src/main/java/org/jbpm/process/workitem/transform/TransformWorkItemHandler.java
@@ -74,7 +74,7 @@ public class TransformWorkItemHandler extends AbstractLogOrThrowWorkItemHandler 
 
             Object in = workItem.getParameter(INPUT_KEY);
             String outputType = (String) workItem.getParameter(OUTPUT_TYPE_KEY);
-            Object output = Class.forName(outputType).newInstance();
+            Object output = Class.forName(outputType).getDeclaredConstructor().newInstance();
             Method txMethod = this.findTransform(output.getClass(),
                                                  in.getClass());
 


### PR DESCRIPTION
To avoid @Deprecated(since="9") warning,
I suggest to replace the newInstance call by clazz.getDeclaredConstructor().newInstance()
as provided by Java11 documentation.



