### PR TITLE
DROOLS-4946: Ignore blocked tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1042,6 +1042,10 @@
           <includes>
             <include>**/*IntegrationTest.java</include>
           </includes>
+          <excludes>
+            <!-- ignored due to DROOLS-4946 -->
+            <exclude>**/itests/CamelWorkitemIntegrationTest.java</exclude>
+          </excludes>
           <argLine>${failsafe.arg.line}</argLine>
         </configuration>
       </plugin>


### PR DESCRIPTION
For more details see https://issues.redhat.com/browse/DROOLS-4946

Ensemble together with:
- https://github.com/kiegroup/droolsjbpm-integration/pull/1983