### PR TITLE
JBPM-9044: removed outdated Wildfly version property

### DIFF
--- a/repository-wildfly/pom.xml
+++ b/repository-wildfly/pom.xml
@@ -17,10 +17,6 @@
     <name>jBPM dev team</name>
   </organization>
 
-  <properties>
-    <version.org.wildfly>11.0.0.Final</version.org.wildfly>
-  </properties>
-
   <dependencies>
 
     <!-- module dependencies -->


### PR DESCRIPTION
https://issues.redhat.com/browse/JBPM-9044

Parent PR kiegroup/droolsjbpm-build-bootstrap/pull/1203