### PR TITLE
JBPM-9204 - Make jbpm-work-items repository compile with JDK 11

### DIFF
--- a/archive-workitem/src/main/java/org/jbpm/process/workitem/archive/ArchiveWorkItemHandler.java
+++ b/archive-workitem/src/main/java/org/jbpm/process/workitem/archive/ArchiveWorkItemHandler.java
@@ -32,6 +32,7 @@ import org.jbpm.process.workitem.core.util.Wid;
 import org.jbpm.process.workitem.core.util.WidMavenDepends;
 import org.jbpm.process.workitem.core.util.WidParameter;
 import org.jbpm.process.workitem.core.util.service.WidAction;
+import org.jbpm.process.workitem.core.util.service.WidAuth;
 import org.jbpm.process.workitem.core.util.service.WidService;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemManager;
@@ -51,7 +52,8 @@ import org.kie.api.runtime.process.WorkItemManager;
         },
         serviceInfo = @WidService(category = "${name}", description = "${description}",
                 keywords = "archive,file,files,zip",
-                action = @WidAction(title = "Archive a list of files.")
+                action = @WidAction(title = "Archive a list of files."),
+                authinfo = @WidAuth
         )
 )
 public class ArchiveWorkItemHandler extends AbstractLogOrThrowWorkItemHandler {

--- a/camel-workitem/pom.xml
+++ b/camel-workitem/pom.xml
@@ -137,6 +137,12 @@
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-test</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.activation</groupId>
+          <artifactId>activation</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>

--- a/camel-workitem/src/main/java/org/jbpm/process/workitem/camel/CXFCamelWorkitemHandler.java
+++ b/camel-workitem/src/main/java/org/jbpm/process/workitem/camel/CXFCamelWorkitemHandler.java
@@ -25,6 +25,7 @@ import org.jbpm.process.workitem.core.util.WidMavenDepends;
 import org.jbpm.process.workitem.core.util.WidParameter;
 import org.jbpm.process.workitem.core.util.WidResult;
 import org.jbpm.process.workitem.core.util.service.WidAction;
+import org.jbpm.process.workitem.core.util.service.WidAuth;
 import org.jbpm.process.workitem.core.util.service.WidService;
 
 @Wid(widfile = "CamelCXFConnector.wid", name = "CamelCXFConnector",
@@ -48,7 +49,8 @@ import org.jbpm.process.workitem.core.util.service.WidService;
         },
         serviceInfo = @WidService(category = "${name}", description = "${description}",
                 keywords = "apache,camel,cxf,payload,route,connector",
-                action = @WidAction(title = "Connect to a JAX-WS service hosted in CXF")
+                action = @WidAction(title = "Connect to a JAX-WS service hosted in CXF"),
+                authinfo = @WidAuth
         )
 
 )

--- a/docker-workitem/src/main/java/org/jbpm/process/workitem/docker/CreateContainerWorkitemHandler.java
+++ b/docker-workitem/src/main/java/org/jbpm/process/workitem/docker/CreateContainerWorkitemHandler.java
@@ -30,6 +30,7 @@ import org.jbpm.process.workitem.core.util.WidMavenDepends;
 import org.jbpm.process.workitem.core.util.WidParameter;
 import org.jbpm.process.workitem.core.util.WidResult;
 import org.jbpm.process.workitem.core.util.service.WidAction;
+import org.jbpm.process.workitem.core.util.service.WidAuth;
 import org.jbpm.process.workitem.core.util.service.WidService;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemManager;
@@ -59,7 +60,8 @@ import org.slf4j.LoggerFactory;
         },
         serviceInfo = @WidService(category = "${name}", description = "${description}",
                 keywords = "Docker,create,container",
-                action = @WidAction(title = "Create Docker container")
+                action = @WidAction(title = "Create Docker container"),
+                authinfo = @WidAuth
         ))
 public class CreateContainerWorkitemHandler extends AbstractLogOrThrowWorkItemHandler {
 

--- a/ethereum-workitem/src/test/java/org/jbpm/process/workitem/ethereum/test/EthereumWorkitemHandlerTest.java
+++ b/ethereum-workitem/src/test/java/org/jbpm/process/workitem/ethereum/test/EthereumWorkitemHandlerTest.java
@@ -67,7 +67,7 @@ import static org.mockito.Mockito.*;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Observable.class})
-@PowerMockIgnore({"javax.crypto.*"})
+@PowerMockIgnore({"javax.crypto.*", "jdk.internal.reflect.*"})
 public class EthereumWorkitemHandlerTest {
 
     private static final String TEST_WALLET_PASSWORD = "jbpmtest123";

--- a/exec-workitem/src/main/java/org/jbpm/process/workitem/exec/ExecWorkItemHandler.java
+++ b/exec-workitem/src/main/java/org/jbpm/process/workitem/exec/ExecWorkItemHandler.java
@@ -30,6 +30,7 @@ import org.jbpm.process.workitem.core.util.WidMavenDepends;
 import org.jbpm.process.workitem.core.util.WidParameter;
 import org.jbpm.process.workitem.core.util.WidResult;
 import org.jbpm.process.workitem.core.util.service.WidAction;
+import org.jbpm.process.workitem.core.util.service.WidAuth;
 import org.jbpm.process.workitem.core.util.service.WidService;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemManager;
@@ -52,7 +53,8 @@ import org.kie.api.runtime.process.WorkItemManager;
         },
         serviceInfo = @WidService(category = "${name}", description = "${description}",
                 keywords = "execute,comand",
-                action = @WidAction(title = "Execute a command")
+                action = @WidAction(title = "Execute a command"),
+                authinfo = @WidAuth
         ))
 public class ExecWorkItemHandler extends AbstractLogOrThrowWorkItemHandler {
 

--- a/ftp-workitem/src/main/java/org/jbpm/process/workitem/ftp/FTPUploadWorkItemHandler.java
+++ b/ftp-workitem/src/main/java/org/jbpm/process/workitem/ftp/FTPUploadWorkItemHandler.java
@@ -29,6 +29,7 @@ import org.jbpm.process.workitem.core.util.Wid;
 import org.jbpm.process.workitem.core.util.WidMavenDepends;
 import org.jbpm.process.workitem.core.util.WidParameter;
 import org.jbpm.process.workitem.core.util.service.WidAction;
+import org.jbpm.process.workitem.core.util.service.WidAuth;
 import org.jbpm.process.workitem.core.util.service.WidService;
 import org.jbpm.process.workitem.email.Connection;
 import org.kie.api.runtime.process.WorkItem;
@@ -53,7 +54,8 @@ import org.slf4j.LoggerFactory;
         },
         serviceInfo = @WidService(category = "${name}", description = "${description}",
                 keywords = "ftp,file,upload",
-                action = @WidAction(title = "Upload a file using FTP")
+                action = @WidAction(title = "Upload a file using FTP"),
+                authinfo = @WidAuth
         ))
 public class FTPUploadWorkItemHandler extends AbstractLogOrThrowWorkItemHandler {
 

--- a/google-drive-workitem/src/test/java/org/jbpm/workitem/google/drive/GoogleDriveWorkitemHandlerTest.java
+++ b/google-drive-workitem/src/test/java/org/jbpm/workitem/google/drive/GoogleDriveWorkitemHandlerTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -43,6 +44,7 @@ import static org.mockito.Matchers.anyString;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"jdk.internal.reflect.*"})
 @PrepareForTest({MediaHttpUploader.class, MediaHttpDownloader.class, Drive.Files.Insert.class, Drive.Files.Get.class})
 public class GoogleDriveWorkitemHandlerTest extends AbstractBaseTest {
 

--- a/google-mail-workitem/pom.xml
+++ b/google-mail-workitem/pom.xml
@@ -258,4 +258,20 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>jdk-11-compile</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <dependencies>
+        <!-- Needed for JDK 11 -->
+        <dependency>
+          <groupId>javax.activation</groupId>
+          <artifactId>activation</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
 </project>

--- a/java-workitem/src/main/java/org/jbpm/process/workitem/handler/JavaHandlerWorkItemHandler.java
+++ b/java-workitem/src/main/java/org/jbpm/process/workitem/handler/JavaHandlerWorkItemHandler.java
@@ -25,6 +25,7 @@ import org.jbpm.process.workitem.core.util.Wid;
 import org.jbpm.process.workitem.core.util.WidMavenDepends;
 import org.jbpm.process.workitem.core.util.WidParameter;
 import org.jbpm.process.workitem.core.util.service.WidAction;
+import org.jbpm.process.workitem.core.util.service.WidAuth;
 import org.jbpm.process.workitem.core.util.service.WidService;
 import org.jbpm.workflow.instance.node.WorkItemNodeInstance;
 import org.kie.api.runtime.KieSession;
@@ -50,7 +51,8 @@ import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
         },
         serviceInfo = @WidService(category = "${name}", description = "${description}",
                 keywords = "java,handler,class,execute",
-                action = @WidAction(title = "Execute an existing Java Workitem Handler")
+                action = @WidAction(title = "Execute an existing Java Workitem Handler"),
+                authinfo = @WidAuth
         ))
 public class JavaHandlerWorkItemHandler extends AbstractLogOrThrowWorkItemHandler {
 

--- a/java-workitem/src/main/java/org/jbpm/process/workitem/java/JavaInvocationWorkItemHandler.java
+++ b/java-workitem/src/main/java/org/jbpm/process/workitem/java/JavaInvocationWorkItemHandler.java
@@ -30,6 +30,7 @@ import org.jbpm.process.workitem.core.util.WidMavenDepends;
 import org.jbpm.process.workitem.core.util.WidParameter;
 import org.jbpm.process.workitem.core.util.WidResult;
 import org.jbpm.process.workitem.core.util.service.WidAction;
+import org.jbpm.process.workitem.core.util.service.WidAuth;
 import org.jbpm.process.workitem.core.util.service.WidService;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemManager;
@@ -55,7 +56,8 @@ import org.kie.api.runtime.process.WorkItemManager;
         },
         serviceInfo = @WidService(category = "${name}", description = "${description}",
                 keywords = "java,class,execute,invoke",
-                action = @WidAction(title = "Execute a method on a Java class")
+                action = @WidAction(title = "Execute a method on a Java class"),
+                authinfo = @WidAuth
         ))
 public class JavaInvocationWorkItemHandler extends AbstractLogOrThrowWorkItemHandler {
 

--- a/jpa-workitem/pom.xml
+++ b/jpa-workitem/pom.xml
@@ -59,6 +59,12 @@
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-test</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.activation</groupId>
+          <artifactId>activation</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>

--- a/mavenembedder-workitem/src/main/java/org/jbpm/process/workitem/mavenembedder/MavenEmbedderWorkItemHandler.java
+++ b/mavenembedder-workitem/src/main/java/org/jbpm/process/workitem/mavenembedder/MavenEmbedderWorkItemHandler.java
@@ -26,6 +26,7 @@ import org.jbpm.process.workitem.core.util.WidMavenDepends;
 import org.jbpm.process.workitem.core.util.WidParameter;
 import org.jbpm.process.workitem.core.util.WidResult;
 import org.jbpm.process.workitem.core.util.service.WidAction;
+import org.jbpm.process.workitem.core.util.service.WidAuth;
 import org.jbpm.process.workitem.core.util.service.WidService;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.manager.RuntimeManager;
@@ -57,7 +58,8 @@ import org.slf4j.LoggerFactory;
         },
         serviceInfo = @WidService(category = "${name}", description = "${description}",
                 keywords = "maven,mvn,build,execute,pom,project,intall",
-                action = @WidAction(title = "Execute Maven commands")
+                action = @WidAction(title = "Execute Maven commands"),
+                authinfo = @WidAuth
         ))
 public class MavenEmbedderWorkItemHandler extends AbstractLogOrThrowWorkItemHandler {
 

--- a/mavenembedder-workitem/src/test/java/org/jbpm/process/workitem/mavenembedder/MavenEmbedderWorkitemHandlerTest.java
+++ b/mavenembedder-workitem/src/test/java/org/jbpm/process/workitem/mavenembedder/MavenEmbedderWorkitemHandlerTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.*;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(RuntimeManagerRegistry.class)
-@PowerMockIgnore({"javax.net.*", "javax.security.*"})
+@PowerMockIgnore({"javax.*", "javax.security.*", "jdk.internal.reflect.*", "org.drools.compiler.*"})
 public class MavenEmbedderWorkitemHandlerTest extends AbstractBaseTest {
 
     @Before

--- a/openweathermap-workitem/src/test/java/org/jbpm/process/workitem/owm/OpenWeatherMapWorkitemHandlerTest.java
+++ b/openweathermap-workitem/src/test/java/org/jbpm/process/workitem/owm/OpenWeatherMapWorkitemHandlerTest.java
@@ -36,6 +36,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -46,6 +47,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({OWM.class, CurrentWeather.class, DailyWeatherForecast.class, Main.class, City.class, ForecastData.class, Temp.class})
+@PowerMockIgnore({"jdk.internal.reflect.*"})
 public class OpenWeatherMapWorkitemHandlerTest extends AbstractBaseTest {
 
     private OWM owm;

--- a/parser-workitem/pom.xml
+++ b/parser-workitem/pom.xml
@@ -138,4 +138,32 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>jdk-11-compile</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <dependencies>
+        <!-- Needed for JDK 11 -->
+        <dependency>
+          <groupId>org.jboss.spec.javax.xml.bind</groupId>
+          <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-core</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>javax.activation</groupId>
+          <artifactId>activation</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
 </project>

--- a/parser-workitem/src/main/java/org/jbpm/process/workitem/parser/ParserWorkItemHandler.java
+++ b/parser-workitem/src/main/java/org/jbpm/process/workitem/parser/ParserWorkItemHandler.java
@@ -35,6 +35,7 @@ import org.jbpm.process.workitem.core.util.WidMavenDepends;
 import org.jbpm.process.workitem.core.util.WidParameter;
 import org.jbpm.process.workitem.core.util.WidResult;
 import org.jbpm.process.workitem.core.util.service.WidAction;
+import org.jbpm.process.workitem.core.util.service.WidAuth;
 import org.jbpm.process.workitem.core.util.service.WidService;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemManager;
@@ -75,7 +76,8 @@ import org.kie.api.runtime.process.WorkItemManager;
         },
         serviceInfo = @WidService(category = "${name}", description = "${description}",
                 keywords = "parse,java,object,string,xml,json",
-                action = @WidAction(title = "Parse Java object to string and vice-versa")
+                action = @WidAction(title = "Parse Java object to string and vice-versa"),
+                authinfo = @WidAuth
         ))
 public class ParserWorkItemHandler extends AbstractLogOrThrowWorkItemHandler {
 

--- a/pdf-workitem/src/main/java/org/jbpm/process/workitem/pdf/GeneratePDFWorkitemHandler.java
+++ b/pdf-workitem/src/main/java/org/jbpm/process/workitem/pdf/GeneratePDFWorkitemHandler.java
@@ -34,6 +34,7 @@ import org.jbpm.process.workitem.core.util.WidMavenDepends;
 import org.jbpm.process.workitem.core.util.WidParameter;
 import org.jbpm.process.workitem.core.util.WidResult;
 import org.jbpm.process.workitem.core.util.service.WidAction;
+import org.jbpm.process.workitem.core.util.service.WidAuth;
 import org.jbpm.process.workitem.core.util.service.WidService;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemManager;
@@ -59,7 +60,8 @@ import org.xhtmlrenderer.pdf.ITextRenderer;
         },
         serviceInfo = @WidService(category = "${name}", description = "${description}",
                 keywords = "pdf,generate,template,document,freemarker,xhtml",
-                action = @WidAction(title = "Generate PDF document")
+                action = @WidAction(title = "Generate PDF document"),
+                authinfo = @WidAuth
         ))
 public class GeneratePDFWorkitemHandler extends AbstractLogOrThrowWorkItemHandler {
 

--- a/rss-workitem/src/main/java/org/jbpm/process/workitem/rss/RSSWorkItemHandler.java
+++ b/rss-workitem/src/main/java/org/jbpm/process/workitem/rss/RSSWorkItemHandler.java
@@ -29,6 +29,7 @@ import org.jbpm.process.workitem.core.util.Wid;
 import org.jbpm.process.workitem.core.util.WidMavenDepends;
 import org.jbpm.process.workitem.core.util.WidParameter;
 import org.jbpm.process.workitem.core.util.service.WidAction;
+import org.jbpm.process.workitem.core.util.service.WidAuth;
 import org.jbpm.process.workitem.core.util.service.WidService;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemManager;
@@ -47,7 +48,8 @@ import org.kie.api.runtime.process.WorkItemManager;
         },
         serviceInfo = @WidService(category = "${name}", description = "${description}",
                 keywords = "rss,feed,create",
-                action = @WidAction(title = "Create a RSS feed from multiple sources")
+                action = @WidAction(title = "Create a RSS feed from multiple sources"),
+                authinfo = @WidAuth
         ))
 public class RSSWorkItemHandler extends AbstractLogOrThrowWorkItemHandler {
 

--- a/transform-workitem/src/main/java/org/jbpm/process/workitem/transform/TransformWorkItemHandler.java
+++ b/transform-workitem/src/main/java/org/jbpm/process/workitem/transform/TransformWorkItemHandler.java
@@ -27,6 +27,7 @@ import org.jbpm.process.workitem.core.util.WidMavenDepends;
 import org.jbpm.process.workitem.core.util.WidParameter;
 import org.jbpm.process.workitem.core.util.WidResult;
 import org.jbpm.process.workitem.core.util.service.WidAction;
+import org.jbpm.process.workitem.core.util.service.WidAuth;
 import org.jbpm.process.workitem.core.util.service.WidService;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemManager;
@@ -51,7 +52,8 @@ import org.slf4j.LoggerFactory;
         },
         serviceInfo = @WidService(category = "${name}", description = "${description}",
                 keywords = "transform,input,output",
-                action = @WidAction(title = "Transforma a Java input Object to an output Object")
+                action = @WidAction(title = "Transforma a Java input Object to an output Object"),
+                authinfo = @WidAuth
         ))
 public class TransformWorkItemHandler extends AbstractLogOrThrowWorkItemHandler {
 

--- a/twitter-workitem/src/test/java/org/jbpm/process/workitem/twitter/TwitterWorkitemHandlerTest.java
+++ b/twitter-workitem/src/test/java/org/jbpm/process/workitem/twitter/TwitterWorkitemHandlerTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
 import twitter4j.DirectMessage;
 import twitter4j.Status;
@@ -36,6 +37,7 @@ import static org.mockito.Matchers.anyString;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"jdk.internal.reflect.*"})
 public class TwitterWorkitemHandlerTest extends AbstractBaseTest {
 
     @Mock


### PR DESCRIPTION
I have managed to make this repo compilable with JDK 11 (mvn clean install -DskipTests). Tests work in all modules but two:

* mavenembedder-workitem because there are some issues with Eclipse JDK compiler
* karaf-itests because these tests use pax-exam-junit4 dependency which seems to be not working with JDK 11 in the version we use now
