### PR TITLE
[JBPM-9439]  Align Kafka emmiter and workitem dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,6 @@
     <version.json>20140107</version.json>
     <version.google.maps>0.9.0</version.google.maps>
     <version.okta>1.3.0</version.okta>
-    <version.kafka>2.3.1</version.kafka>
     <version.docker-java>3.0.14</version.docker-java>
     <!-- OSGI tests properties -->
     <version.org.apache.karaf>4.2.0</version.org.apache.karaf>
@@ -246,16 +245,10 @@
         <version>${version.atlassian.jira}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.kafka</groupId>
-        <artifactId>kafka-clients</artifactId>
-        <version>${version.kafka}</version>
-      </dependency>
-      <dependency>
         <groupId>com.github.docker-java</groupId>
         <artifactId>docker-java</artifactId>
         <version>${version.docker-java}</version>
       </dependency>
-
       <dependency>
         <groupId>org.web3j</groupId>
         <artifactId>core</artifactId>


### PR DESCRIPTION
Removing kafka dependencies from jbpm-workitems pom, so they are
inherited from kie-parent

**JIRA**: 

[JBPM-9439](https://issues.redhat.com/browse/JBPM-9439)

Depends on 
[#1495](https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1495)
