### PR TITLE
[JBPM-9453] Exclusions needed at spring-boot-starter-test after bumping to junit 4.13.1

### DIFF
--- a/jbpm-workitem-itests/pom.xml
+++ b/jbpm-workitem-itests/pom.xml
@@ -136,6 +136,14 @@
           <groupId>org.springframework</groupId>
           <artifactId>spring-jcl</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
**JIRA**: [JBPM-9453](https://issues.redhat.com/browse/JBPM-9453)

