### PR TITLE
[7.52.x] [RHPAM-3677] Exclusions needed at spring-boot-starter-test after bumping to junit 4.13.1

### DIFF
--- a/jbpm-workitem-itests/pom.xml
+++ b/jbpm-workitem-itests/pom.xml
@@ -136,6 +136,14 @@
           <groupId>org.springframework</groupId>
           <artifactId>spring-jcl</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/jbpm-workitem-itests/pom.xml
+++ b/jbpm-workitem-itests/pom.xml
@@ -68,10 +68,6 @@
           <artifactId>jaxb-runtime</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-        <exclusion>
             <groupId>org.jboss.spec.javax.el</groupId>
             <artifactId>jboss-el-api_3.0_spec</artifactId>
         </exclusion>


### PR DESCRIPTION
**JIRA**: [RHPAM-3677](https://issues.redhat.com/browse/RHPAM-3677)

jbpm-workitem-itests (integration tests for Kafka WorkItem Handler) have not been executed for CR1 due to these fixes (applied to other modules) were not included in this one.

@MarianMacik could you review?