### PR TITLE
use version property used in KIE parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <version.org.xhtmlrenderer>9.1.15</version.org.xhtmlrenderer>
     <version.bouncycastle>1.67</version.bouncycastle>
     <version.xmlsec>1.5.1</version.xmlsec>
-    <version.google.guava>29.0-jre</version.google.guava>
+    <version.google.guava>${version.com.google.guava}</version.google.guava>
     <version.riot.api>4.1.0</version.riot.api>
     <version.jpastebin>1.0.1</version.jpastebin>
     <version.vimeo>1.10</version.vimeo>


### PR DESCRIPTION
See https://github.com/kiegroup/jbpm-work-items/security/dependabot/pom.xml/com.google.guava:guava/open
Trying to unify on the same version we have in KIE parent


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
