### PR TITLE
[7.59.x][JBPM-9940] - Kafka WIH tests are failing due to "EntityManagerFactory is closed"

### DIFF
--- a/jbpm-workitem-itests/pom.xml
+++ b/jbpm-workitem-itests/pom.xml
@@ -198,6 +198,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
+            <reuseForks>false</reuseForks>
             <systemPropertyVariables>
               <toxiproxy.image>shopify/toxiproxy:2.1.4</toxiproxy.image>
               <toxiproxy.port>9093</toxiproxy.port>


### PR DESCRIPTION
Backport of https://github.com/kiegroup/jbpm-work-items/pull/224