### PR TITLE
[JBPM-10093] - Adapt testcontainers to support and use a particular Kafka version

### DIFF
--- a/jbpm-workitem-itests/pom.xml
+++ b/jbpm-workitem-itests/pom.xml
@@ -203,6 +203,7 @@
               <toxiproxy.image>shopify/toxiproxy:2.1.4</toxiproxy.image>
               <toxiproxy.port>9093</toxiproxy.port>
               <org.kie.executor.jms>false</org.kie.executor.jms>
+              <kafka.container.version>${version.org.apache.kafka}</kafka.container.version>
             </systemPropertyVariables>
           </configuration>
         </plugin>

--- a/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaFixture.java
+++ b/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaFixture.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 
-import io.strimzi.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaContainer;
 
 import static java.util.Collections.singletonList;
 

--- a/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaProxyBase.java
+++ b/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaProxyBase.java
@@ -38,7 +38,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import io.strimzi.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaContainer;
 
 import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;
@@ -63,7 +63,9 @@ public abstract class KafkaProxyBase extends KafkaBaseTest {
     public Network network = Network.newNetwork();
 
     @Rule
-    public StrimziKafkaContainer kafka = new StrimziKafkaContainer().withNetwork(network);
+    public StrimziKafkaContainer kafka = new StrimziKafkaContainer()
+                                                .withKafkaVersion(System.getProperty("kafka.container.version"))
+                                                .withNetwork(network);
 
     @Rule
     public ToxiproxyContainer toxiproxy  = new ToxiproxyContainer(DockerImageName.parse(TOXIPROXY_IMAGE))

--- a/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaSampleTest.java
+++ b/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaSampleTest.java
@@ -34,7 +34,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
-import io.strimzi.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaContainer;
 
 import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;

--- a/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaSerializationTest.java
+++ b/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaSerializationTest.java
@@ -34,7 +34,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
-import io.strimzi.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaContainer;
 
 import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;


### PR DESCRIPTION
**[JBPM-10093](https://issues.redhat.com/browse/JBPM-10093)**

**referenced Pull Requests**:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1983

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
