### PR TITLE
[7.67.x][JBPM-10093] - Adapt testcontainers to support and use a particular Kafka version

### DIFF
--- a/jbpm-workitem-itests/pom.xml
+++ b/jbpm-workitem-itests/pom.xml
@@ -203,6 +203,7 @@
               <toxiproxy.image>shopify/toxiproxy:2.1.4</toxiproxy.image>
               <toxiproxy.port>9093</toxiproxy.port>
               <org.kie.executor.jms>false</org.kie.executor.jms>
+              <kafka.container.version>${version.org.apache.kafka}</kafka.container.version>
             </systemPropertyVariables>
           </configuration>
         </plugin>

--- a/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaFixture.java
+++ b/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaFixture.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 
-import io.strimzi.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaContainer;
 
 import static java.util.Collections.singletonList;
 

--- a/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaProxyBase.java
+++ b/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaProxyBase.java
@@ -38,7 +38,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import io.strimzi.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaContainer;
 
 import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;
@@ -63,7 +63,9 @@ public abstract class KafkaProxyBase extends KafkaBaseTest {
     public Network network = Network.newNetwork();
 
     @Rule
-    public StrimziKafkaContainer kafka = new StrimziKafkaContainer().withNetwork(network);
+    public StrimziKafkaContainer kafka = new StrimziKafkaContainer()
+                                                .withKafkaVersion(System.getProperty("kafka.container.version"))
+                                                .withNetwork(network);
 
     @Rule
     public ToxiproxyContainer toxiproxy  = new ToxiproxyContainer(DockerImageName.parse(TOXIPROXY_IMAGE))

--- a/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaSampleTest.java
+++ b/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaSampleTest.java
@@ -34,7 +34,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
-import io.strimzi.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaContainer;
 
 import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;

--- a/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaSerializationTest.java
+++ b/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaSerializationTest.java
@@ -34,7 +34,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
-import io.strimzi.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaContainer;
 
 import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;


### PR DESCRIPTION
Backport of https://github.com/kiegroup/jbpm-work-items/pull/234/commits/c6736de444eeddebbd3299ed19c41333cee377ca