### PR TITLE
[7.67.x-blue] RHPAM-3709: upgrade maven dependencies to address CVE-2021-26291

### DIFF
--- a/jbpm-workitem-itests/pom.xml
+++ b/jbpm-workitem-itests/pom.xml
@@ -117,10 +117,6 @@
           <artifactId>hamcrest</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-jcl</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.junit.jupiter</groupId>
           <artifactId>junit-jupiter</artifactId>
         </exclusion>

--- a/mavenembedder-workitem/pom.xml
+++ b/mavenembedder-workitem/pom.xml
@@ -59,11 +59,11 @@
           <artifactId>org.eclipse.sisu.plexus</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.sonatype.plexus</groupId>
+          <groupId>org.codehaus.plexus</groupId>
           <artifactId>plexus-sec-dispatcher</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.sonatype.plexus</groupId>
+          <groupId>org.codehaus.plexus</groupId>
           <artifactId>plexus-cipher</artifactId>
         </exclusion>
       </exclusions>
@@ -114,23 +114,23 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.plexus</groupId>
+      <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-sec-dispatcher</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.plexus</groupId>
+      <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-cipher</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-connector-basic</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-connector-basic</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-wagon</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-wagon</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -141,11 +141,6 @@
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-http-lightweight</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,9 @@
     <version.rxjava>1.2.4</version.rxjava>
     <version.owm>2.5.2.2</version.owm>
     <version.commons.net>3.6</version.commons.net>
-    <version.maven.embedder>3.3.3</version.maven.embedder>
     <version.wildfly.maven.plugin>1.2.1.Final</version.wildfly.maven.plugin>
     <version.war.plugin>3.2.2</version.war.plugin>
     <version.apache.commons.io>2.5</version.apache.commons.io>
-    <version.maven.model>3.3.9</version.maven.model>
     <version.jslack>1.1.4</version.jslack>
     <version.org.xhtmlrenderer>9.1.15</version.org.xhtmlrenderer>
     <version.bouncycastle>1.67</version.bouncycastle>
@@ -471,41 +469,6 @@
         <groupId>commons-net</groupId>
         <artifactId>commons-net</artifactId>
         <version>${version.commons.net}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-embedder</artifactId>
-        <version>${version.maven.embedder}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-connector-basic</artifactId>
-        <version>${version.org.eclipse.aether}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-transport-wagon</artifactId>
-        <version>${version.org.eclipse.aether}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.wagon</groupId>
-        <artifactId>wagon-http</artifactId>
-        <version>${version.org.apache.maven.wagon}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.wagon</groupId>
-        <artifactId>wagon-provider-api</artifactId>
-        <version>${version.org.apache.maven.wagon}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.wagon</groupId>
-        <artifactId>wagon-http-lightweight</artifactId>
-        <version>${version.org.apache.maven.wagon}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-model</artifactId>
-        <version>${version.maven.model}</version>
       </dependency>
       <dependency>
         <groupId>com.github.taycaldwell</groupId>


### PR DESCRIPTION
Replaces https://github.com/kiegroup/jbpm-work-items/pull/297