### PR TITLE
[CVE][HIGH] CVE-2021-40690 Updating xmlsec library

### DIFF
--- a/pdf-workitem/pom.xml
+++ b/pdf-workitem/pom.xml
@@ -45,7 +45,6 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15to18</artifactId>
     </dependency>
-    <!--
     <dependency>
       <groupId>org.apache.santuario</groupId>
       <artifactId>xmlsec</artifactId>
@@ -56,7 +55,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    -->
 
     <dependency>
       <groupId>org.kie</groupId>

--- a/pdf-workitem/pom.xml
+++ b/pdf-workitem/pom.xml
@@ -45,6 +45,7 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15to18</artifactId>
     </dependency>
+    <!--
     <dependency>
       <groupId>org.apache.santuario</groupId>
       <artifactId>xmlsec</artifactId>
@@ -55,6 +56,7 @@
         </exclusion>
       </exclusions>
     </dependency>
+    -->
 
     <dependency>
       <groupId>org.kie</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <version.apache.commons.io>2.5</version.apache.commons.io>
     <version.jslack>1.1.4</version.jslack>
     <version.org.xhtmlrenderer>9.1.15</version.org.xhtmlrenderer>
-    <version.xmlsec>2.2.6</version.xmlsec>
+    <!-- <version.xmlsec>2.2.6</version.xmlsec> -->
     <version.google.guava>${version.com.google.guava}</version.google.guava>
     <version.riot.api>4.1.0</version.riot.api>
     <version.jpastebin>1.0.1</version.jpastebin>
@@ -334,11 +334,13 @@
         <artifactId>flying-saucer-pdf-itext5</artifactId>
         <version>${version.org.xhtmlrenderer}</version>
       </dependency>
+      <!--
       <dependency>
         <groupId>org.apache.santuario</groupId>
         <artifactId>xmlsec</artifactId>
         <version>${version.xmlsec}</version>
       </dependency>
+      -->
       <dependency>
         <groupId>com.clickntap</groupId>
         <artifactId>vimeo</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <version.apache.commons.io>2.5</version.apache.commons.io>
     <version.jslack>1.1.4</version.jslack>
     <version.org.xhtmlrenderer>9.1.15</version.org.xhtmlrenderer>
-    <!-- <version.xmlsec>2.2.6</version.xmlsec> -->
+    <version.xmlsec>2.2.6</version.xmlsec>
     <version.google.guava>${version.com.google.guava}</version.google.guava>
     <version.riot.api>4.1.0</version.riot.api>
     <version.jpastebin>1.0.1</version.jpastebin>
@@ -334,13 +334,11 @@
         <artifactId>flying-saucer-pdf-itext5</artifactId>
         <version>${version.org.xhtmlrenderer}</version>
       </dependency>
-      <!--
       <dependency>
         <groupId>org.apache.santuario</groupId>
         <artifactId>xmlsec</artifactId>
         <version>${version.xmlsec}</version>
       </dependency>
-      -->
       <dependency>
         <groupId>com.clickntap</groupId>
         <artifactId>vimeo</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <version.apache.commons.io>2.5</version.apache.commons.io>
     <version.jslack>1.1.4</version.jslack>
     <version.org.xhtmlrenderer>9.1.15</version.org.xhtmlrenderer>
-    <version.xmlsec>1.5.1</version.xmlsec>
+    <version.xmlsec>2.2.6</version.xmlsec>
     <version.google.guava>${version.com.google.guava}</version.google.guava>
     <version.riot.api>4.1.0</version.riot.api>
     <version.jpastebin>1.0.1</version.jpastebin>


### PR DESCRIPTION
Fixes a CVE in xmlsec.

There's a CVE in the version of xmlsec that we use, it was fixed in 2.2.3, but we're also using version 2.2.6 elsewhere in the codebase, so I figured it made sense to use the same version in both places.
