### PR TITLE
DBACLD-199586 : CVE Fix - netty-codec-http

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '03:00'
+  open-pull-requests-limit: 10
+  target-branch: "main"
+  commit-message:
+    prefix: "[bot][main]"
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '04:00'
+  open-pull-requests-limit: 10
+  target-branch: "7.67.x"
+  commit-message:
+    prefix: "[bot][7.67.x]"
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '05:00'
+  open-pull-requests-limit: 10
+  target-branch: "7.67.x-blue"
+  commit-message:
+    prefix: "[bot][blue]"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: daily
     time: '03:00'
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   target-branch: "main"
   commit-message:
     prefix: "[bot][main]"
@@ -14,7 +14,7 @@ updates:
   schedule:
     interval: daily
     time: '04:00'
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   target-branch: "7.67.x"
   commit-message:
     prefix: "[bot][7.67.x]"
@@ -23,7 +23,7 @@ updates:
   schedule:
     interval: daily
     time: '05:00'
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   target-branch: "7.67.x-blue"
   commit-message:
     prefix: "[bot][blue]"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,3 +35,19 @@ How to retest this PR or trigger a specific build:
 
 * <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
 </details>
+
+<details>
+<summary>
+How to backport a pull request to a different branch?
+</summary>
+
+In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).
+
+> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.
+
+Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.
+
+If something goes wrong, the author will be notified and at this point a manual backporting is needed.
+
+> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
+</details>

--- a/.github/workflows/pr-backporting.yml
+++ b/.github/workflows/pr-backporting.yml
@@ -1,0 +1,43 @@
+name: Pull Request Backporting
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+    branches:
+      - main
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  compute-targets:
+    if: ${{ github.event.pull_request.state == 'closed' && github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    outputs:
+      target-branches: ${{ steps.set-targets.outputs.targets }}
+    env:
+      LABELS: ${{ toJSON(github.event.pull_request.labels) }}
+    steps:
+      - name: Set target branches
+        id: set-targets
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/parse-labels@main
+        with:
+          labels: ${LABELS}
+  
+  backporting:
+    if: ${{ github.event.pull_request.state == 'closed' && github.event.pull_request.merged && needs.compute-targets.outputs.target-branches != '[]' }}
+    name: "[${{ matrix.target-branch }}] - Backporting"
+    runs-on: ubuntu-latest
+    needs: compute-targets
+    strategy:
+      matrix: 
+        target-branch: ${{ fromJSON(needs.compute-targets.outputs.target-branches) }}
+      fail-fast: true
+    env:
+      REVIEWERS: ${{ toJSON(github.event.pull_request.requested_reviewers) }}
+    steps:
+      - name: Backporting
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/backporting@main
+        with:
+          target-branch: ${{ matrix.target-branch }}
+          additional-reviewers: ${REVIEWERS}

--- a/.github/workflows/pr-backporting.yml
+++ b/.github/workflows/pr-backporting.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Set target branches
         id: set-targets
-        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/parse-labels@main
+        uses: kiegroup/kie-ci/.ci/actions/parse-labels@main
         with:
           labels: ${LABELS}
   
@@ -37,7 +37,7 @@ jobs:
       REVIEWERS: ${{ toJSON(github.event.pull_request.requested_reviewers) }}
     steps:
       - name: Backporting
-        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/backporting@main
+        uses: kiegroup/kie-ci/.ci/actions/backporting@main
         with:
           target-branch: ${{ matrix.target-branch }}
           additional-reviewers: ${REVIEWERS}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build-chain:
     concurrency:
-      group: pull_request-${{ github.head_ref }}
+      group: pull_request-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.java-version }}
       cancel-in-progress: true
     strategy:
       matrix:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,26 +20,27 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java-version: [8, 11]
-        maven-version: ['3.8.1']
+        maven-version: ['3.8.2']
       fail-fast: true
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven
     steps:
       - name: Support long paths
         if: ${{ matrix.os == 'windows-latest' }}
-        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/long-paths@main
+        uses: kiegroup/kie-ci/.ci/actions/long-paths@main
       - name: Java and Maven Setup
-        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/maven@main
+        uses: kiegroup/kie-ci/.ci/actions/maven@main
         with:
           java-version: ${{ matrix.java-version }}
           maven-version: ${{ matrix.maven-version }}
           cache-key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
       - name: Build Chain
-        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/build-chain@main
+        uses: kiegroup/kie-ci/.ci/actions/build-chain@main
         with:
+          definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Surefire Report
-        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/surefire-report@main
+        uses: kiegroup/kie-ci/.ci/actions/surefire-report@main
         if: ${{ always() }}
                                         

--- a/archive-workitem/pom.xml
+++ b/archive-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>archive-workitem</artifactId>

--- a/archive-workitem/pom.xml
+++ b/archive-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>archive-workitem</artifactId>

--- a/archive-workitem/pom.xml
+++ b/archive-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>archive-workitem</artifactId>

--- a/archive-workitem/pom.xml
+++ b/archive-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>archive-workitem</artifactId>

--- a/archive-workitem/pom.xml
+++ b/archive-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>archive-workitem</artifactId>

--- a/archive-workitem/pom.xml
+++ b/archive-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>archive-workitem</artifactId>

--- a/archive-workitem/pom.xml
+++ b/archive-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>archive-workitem</artifactId>

--- a/archive-workitem/pom.xml
+++ b/archive-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>archive-workitem</artifactId>

--- a/camel-workitem/pom.xml
+++ b/camel-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-workitem</artifactId>

--- a/camel-workitem/pom.xml
+++ b/camel-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-workitem</artifactId>

--- a/camel-workitem/pom.xml
+++ b/camel-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-workitem</artifactId>

--- a/camel-workitem/pom.xml
+++ b/camel-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-workitem</artifactId>

--- a/camel-workitem/pom.xml
+++ b/camel-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-workitem</artifactId>

--- a/camel-workitem/pom.xml
+++ b/camel-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-workitem</artifactId>

--- a/camel-workitem/pom.xml
+++ b/camel-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-workitem</artifactId>

--- a/camel-workitem/pom.xml
+++ b/camel-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-workitem</artifactId>

--- a/camel-workitem/src/test/java/org/jbpm/process/workitem/camel/CamelSqlTest.java
+++ b/camel-workitem/src/test/java/org/jbpm/process/workitem/camel/CamelSqlTest.java
@@ -85,7 +85,7 @@ public class CamelSqlTest {
      */
     private static void setupDb() throws SQLException, URISyntaxException {
         File script = new File(CamelSqlTest.class.getResource("/init-db.sql").toURI());
-        RunScript.execute("jdbc:h2:mem:jbpm-db;MVCC=true",
+        RunScript.execute("jdbc:h2:mem:jbpm-db;MODE=LEGACY;NON_KEYWORDS=VALUE",
                           "sa",
                           "",
                           script.getAbsolutePath(),

--- a/docker-workitem/pom.xml
+++ b/docker-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>docker-workitem</artifactId>

--- a/docker-workitem/pom.xml
+++ b/docker-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>docker-workitem</artifactId>

--- a/docker-workitem/pom.xml
+++ b/docker-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>docker-workitem</artifactId>

--- a/docker-workitem/pom.xml
+++ b/docker-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>docker-workitem</artifactId>

--- a/docker-workitem/pom.xml
+++ b/docker-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>docker-workitem</artifactId>

--- a/docker-workitem/pom.xml
+++ b/docker-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>docker-workitem</artifactId>

--- a/docker-workitem/pom.xml
+++ b/docker-workitem/pom.xml
@@ -25,6 +25,14 @@
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk15on</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/docker-workitem/pom.xml
+++ b/docker-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>docker-workitem</artifactId>

--- a/docker-workitem/pom.xml
+++ b/docker-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>docker-workitem</artifactId>

--- a/docker-workitem/pom.xml
+++ b/docker-workitem/pom.xml
@@ -33,6 +33,10 @@
           <groupId>org.bouncycastle</groupId>
           <artifactId>bcpkix-jdk15on</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.github.docker-java</groupId>
+          <artifactId>docker-java-transport-netty</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/dropbox-workitem/pom.xml
+++ b/dropbox-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dropbox-workitem</artifactId>

--- a/dropbox-workitem/pom.xml
+++ b/dropbox-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dropbox-workitem</artifactId>

--- a/dropbox-workitem/pom.xml
+++ b/dropbox-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dropbox-workitem</artifactId>

--- a/dropbox-workitem/pom.xml
+++ b/dropbox-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dropbox-workitem</artifactId>

--- a/dropbox-workitem/pom.xml
+++ b/dropbox-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dropbox-workitem</artifactId>

--- a/dropbox-workitem/pom.xml
+++ b/dropbox-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dropbox-workitem</artifactId>

--- a/dropbox-workitem/pom.xml
+++ b/dropbox-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dropbox-workitem</artifactId>

--- a/dropbox-workitem/pom.xml
+++ b/dropbox-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dropbox-workitem</artifactId>

--- a/ethereum-workitem/pom.xml
+++ b/ethereum-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ethereum-workitem</artifactId>

--- a/ethereum-workitem/pom.xml
+++ b/ethereum-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ethereum-workitem</artifactId>

--- a/ethereum-workitem/pom.xml
+++ b/ethereum-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ethereum-workitem</artifactId>

--- a/ethereum-workitem/pom.xml
+++ b/ethereum-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ethereum-workitem</artifactId>

--- a/ethereum-workitem/pom.xml
+++ b/ethereum-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ethereum-workitem</artifactId>

--- a/ethereum-workitem/pom.xml
+++ b/ethereum-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ethereum-workitem</artifactId>

--- a/ethereum-workitem/pom.xml
+++ b/ethereum-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ethereum-workitem</artifactId>

--- a/ethereum-workitem/pom.xml
+++ b/ethereum-workitem/pom.xml
@@ -40,6 +40,12 @@
       <groupId>org.web3j</groupId>
       <artifactId>utils</artifactId>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>
@@ -133,6 +139,12 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>template-resources</artifactId>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15to18</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/ethereum-workitem/pom.xml
+++ b/ethereum-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ethereum-workitem</artifactId>

--- a/exec-workitem/pom.xml
+++ b/exec-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exec-workitem</artifactId>

--- a/exec-workitem/pom.xml
+++ b/exec-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exec-workitem</artifactId>

--- a/exec-workitem/pom.xml
+++ b/exec-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exec-workitem</artifactId>

--- a/exec-workitem/pom.xml
+++ b/exec-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exec-workitem</artifactId>

--- a/exec-workitem/pom.xml
+++ b/exec-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exec-workitem</artifactId>

--- a/exec-workitem/pom.xml
+++ b/exec-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exec-workitem</artifactId>

--- a/exec-workitem/pom.xml
+++ b/exec-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exec-workitem</artifactId>

--- a/exec-workitem/pom.xml
+++ b/exec-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exec-workitem</artifactId>

--- a/execute-sql-workitem/pom.xml
+++ b/execute-sql-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>execute-sql-workitem</artifactId>

--- a/execute-sql-workitem/pom.xml
+++ b/execute-sql-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>execute-sql-workitem</artifactId>

--- a/execute-sql-workitem/pom.xml
+++ b/execute-sql-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>execute-sql-workitem</artifactId>

--- a/execute-sql-workitem/pom.xml
+++ b/execute-sql-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>execute-sql-workitem</artifactId>

--- a/execute-sql-workitem/pom.xml
+++ b/execute-sql-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>execute-sql-workitem</artifactId>

--- a/execute-sql-workitem/pom.xml
+++ b/execute-sql-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>execute-sql-workitem</artifactId>

--- a/execute-sql-workitem/pom.xml
+++ b/execute-sql-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>execute-sql-workitem</artifactId>

--- a/execute-sql-workitem/pom.xml
+++ b/execute-sql-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>execute-sql-workitem</artifactId>

--- a/execute-sql-workitem/src/test/java/org/jbpm/process/workitem/executesql/ExecuteSqlWorkItemHandlerTest.java
+++ b/execute-sql-workitem/src/test/java/org/jbpm/process/workitem/executesql/ExecuteSqlWorkItemHandlerTest.java
@@ -169,7 +169,7 @@ public class ExecuteSqlWorkItemHandlerTest {
         driverProperties.setProperty("password",
                                      "sa");
         driverProperties.setProperty("url",
-                                     "jdbc:h2:mem:jpa-wih;MVCC=true");
+                                     "jdbc:h2:mem:jpa-wih;MODE=LEGACY;NON_KEYWORDS=VALUE");
         driverProperties.setProperty("driverClassName",
                                      "org.h2.Driver");
 
@@ -185,7 +185,7 @@ public class ExecuteSqlWorkItemHandlerTest {
         public void start() {
             if (realH2Server == null || !realH2Server.isRunning(false)) {
                 try {
-                    realH2Server = Server.createTcpServer(new String[0]);
+                    realH2Server = Server.createTcpServer(new String[]{"-ifNotExists"});
                     realH2Server.start();
                     System.out.println("Started H2 Server...");
                 } catch (SQLException e) {

--- a/ftp-workitem/pom.xml
+++ b/ftp-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ftp-workitem</artifactId>

--- a/ftp-workitem/pom.xml
+++ b/ftp-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ftp-workitem</artifactId>

--- a/ftp-workitem/pom.xml
+++ b/ftp-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ftp-workitem</artifactId>

--- a/ftp-workitem/pom.xml
+++ b/ftp-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ftp-workitem</artifactId>

--- a/ftp-workitem/pom.xml
+++ b/ftp-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ftp-workitem</artifactId>

--- a/ftp-workitem/pom.xml
+++ b/ftp-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ftp-workitem</artifactId>

--- a/ftp-workitem/pom.xml
+++ b/ftp-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ftp-workitem</artifactId>

--- a/ftp-workitem/pom.xml
+++ b/ftp-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ftp-workitem</artifactId>

--- a/github-workitem/pom.xml
+++ b/github-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>github-workitem</artifactId>

--- a/github-workitem/pom.xml
+++ b/github-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>github-workitem</artifactId>

--- a/github-workitem/pom.xml
+++ b/github-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>github-workitem</artifactId>

--- a/github-workitem/pom.xml
+++ b/github-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>github-workitem</artifactId>

--- a/github-workitem/pom.xml
+++ b/github-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>github-workitem</artifactId>

--- a/github-workitem/pom.xml
+++ b/github-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>github-workitem</artifactId>

--- a/github-workitem/pom.xml
+++ b/github-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>github-workitem</artifactId>

--- a/github-workitem/pom.xml
+++ b/github-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>github-workitem</artifactId>

--- a/google-calendar-workitem/pom.xml
+++ b/google-calendar-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-calendar-workitem</artifactId>

--- a/google-calendar-workitem/pom.xml
+++ b/google-calendar-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-calendar-workitem</artifactId>

--- a/google-calendar-workitem/pom.xml
+++ b/google-calendar-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-calendar-workitem</artifactId>

--- a/google-calendar-workitem/pom.xml
+++ b/google-calendar-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-calendar-workitem</artifactId>

--- a/google-calendar-workitem/pom.xml
+++ b/google-calendar-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-calendar-workitem</artifactId>

--- a/google-calendar-workitem/pom.xml
+++ b/google-calendar-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-calendar-workitem</artifactId>

--- a/google-calendar-workitem/pom.xml
+++ b/google-calendar-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-calendar-workitem</artifactId>

--- a/google-calendar-workitem/pom.xml
+++ b/google-calendar-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-calendar-workitem</artifactId>

--- a/google-drive-workitem/pom.xml
+++ b/google-drive-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-drive-workitem</artifactId>

--- a/google-drive-workitem/pom.xml
+++ b/google-drive-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-drive-workitem</artifactId>

--- a/google-drive-workitem/pom.xml
+++ b/google-drive-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-drive-workitem</artifactId>

--- a/google-drive-workitem/pom.xml
+++ b/google-drive-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-drive-workitem</artifactId>

--- a/google-drive-workitem/pom.xml
+++ b/google-drive-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-drive-workitem</artifactId>

--- a/google-drive-workitem/pom.xml
+++ b/google-drive-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-drive-workitem</artifactId>

--- a/google-drive-workitem/pom.xml
+++ b/google-drive-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-drive-workitem</artifactId>

--- a/google-drive-workitem/pom.xml
+++ b/google-drive-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-drive-workitem</artifactId>

--- a/google-mail-workitem/pom.xml
+++ b/google-mail-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-mail-workitem</artifactId>

--- a/google-mail-workitem/pom.xml
+++ b/google-mail-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-mail-workitem</artifactId>

--- a/google-mail-workitem/pom.xml
+++ b/google-mail-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-mail-workitem</artifactId>

--- a/google-mail-workitem/pom.xml
+++ b/google-mail-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-mail-workitem</artifactId>

--- a/google-mail-workitem/pom.xml
+++ b/google-mail-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-mail-workitem</artifactId>

--- a/google-mail-workitem/pom.xml
+++ b/google-mail-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-mail-workitem</artifactId>

--- a/google-mail-workitem/pom.xml
+++ b/google-mail-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-mail-workitem</artifactId>

--- a/google-mail-workitem/pom.xml
+++ b/google-mail-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-mail-workitem</artifactId>

--- a/google-maps-workitem/pom.xml
+++ b/google-maps-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-maps-workitem</artifactId>

--- a/google-maps-workitem/pom.xml
+++ b/google-maps-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-maps-workitem</artifactId>

--- a/google-maps-workitem/pom.xml
+++ b/google-maps-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-maps-workitem</artifactId>

--- a/google-maps-workitem/pom.xml
+++ b/google-maps-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-maps-workitem</artifactId>

--- a/google-maps-workitem/pom.xml
+++ b/google-maps-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-maps-workitem</artifactId>

--- a/google-maps-workitem/pom.xml
+++ b/google-maps-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-maps-workitem</artifactId>

--- a/google-maps-workitem/pom.xml
+++ b/google-maps-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-maps-workitem</artifactId>

--- a/google-maps-workitem/pom.xml
+++ b/google-maps-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-maps-workitem</artifactId>

--- a/google-sheets-workitem/pom.xml
+++ b/google-sheets-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-sheets-workitem</artifactId>

--- a/google-sheets-workitem/pom.xml
+++ b/google-sheets-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-sheets-workitem</artifactId>

--- a/google-sheets-workitem/pom.xml
+++ b/google-sheets-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-sheets-workitem</artifactId>

--- a/google-sheets-workitem/pom.xml
+++ b/google-sheets-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-sheets-workitem</artifactId>

--- a/google-sheets-workitem/pom.xml
+++ b/google-sheets-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-sheets-workitem</artifactId>

--- a/google-sheets-workitem/pom.xml
+++ b/google-sheets-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-sheets-workitem</artifactId>

--- a/google-sheets-workitem/pom.xml
+++ b/google-sheets-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-sheets-workitem</artifactId>

--- a/google-sheets-workitem/pom.xml
+++ b/google-sheets-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-sheets-workitem</artifactId>

--- a/google-tasks-workitem/pom.xml
+++ b/google-tasks-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-tasks-workitem</artifactId>

--- a/google-tasks-workitem/pom.xml
+++ b/google-tasks-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-tasks-workitem</artifactId>

--- a/google-tasks-workitem/pom.xml
+++ b/google-tasks-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-tasks-workitem</artifactId>

--- a/google-tasks-workitem/pom.xml
+++ b/google-tasks-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-tasks-workitem</artifactId>

--- a/google-tasks-workitem/pom.xml
+++ b/google-tasks-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-tasks-workitem</artifactId>

--- a/google-tasks-workitem/pom.xml
+++ b/google-tasks-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-tasks-workitem</artifactId>

--- a/google-tasks-workitem/pom.xml
+++ b/google-tasks-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-tasks-workitem</artifactId>

--- a/google-tasks-workitem/pom.xml
+++ b/google-tasks-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-tasks-workitem</artifactId>

--- a/google-translate-workitem/pom.xml
+++ b/google-translate-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-translate-workitem</artifactId>

--- a/google-translate-workitem/pom.xml
+++ b/google-translate-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-translate-workitem</artifactId>

--- a/google-translate-workitem/pom.xml
+++ b/google-translate-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-translate-workitem</artifactId>

--- a/google-translate-workitem/pom.xml
+++ b/google-translate-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-translate-workitem</artifactId>

--- a/google-translate-workitem/pom.xml
+++ b/google-translate-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-translate-workitem</artifactId>

--- a/google-translate-workitem/pom.xml
+++ b/google-translate-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-translate-workitem</artifactId>

--- a/google-translate-workitem/pom.xml
+++ b/google-translate-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-translate-workitem</artifactId>

--- a/google-translate-workitem/pom.xml
+++ b/google-translate-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-translate-workitem</artifactId>

--- a/ibm-watson-workitem/pom.xml
+++ b/ibm-watson-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ibm-watson-workitem</artifactId>

--- a/ibm-watson-workitem/pom.xml
+++ b/ibm-watson-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ibm-watson-workitem</artifactId>

--- a/ibm-watson-workitem/pom.xml
+++ b/ibm-watson-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ibm-watson-workitem</artifactId>

--- a/ibm-watson-workitem/pom.xml
+++ b/ibm-watson-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ibm-watson-workitem</artifactId>

--- a/ibm-watson-workitem/pom.xml
+++ b/ibm-watson-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ibm-watson-workitem</artifactId>

--- a/ibm-watson-workitem/pom.xml
+++ b/ibm-watson-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ibm-watson-workitem</artifactId>

--- a/ibm-watson-workitem/pom.xml
+++ b/ibm-watson-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ibm-watson-workitem</artifactId>

--- a/ibm-watson-workitem/pom.xml
+++ b/ibm-watson-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ibm-watson-workitem</artifactId>

--- a/ifttt-workitem/pom.xml
+++ b/ifttt-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ifttt-workitem</artifactId>

--- a/ifttt-workitem/pom.xml
+++ b/ifttt-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ifttt-workitem</artifactId>

--- a/ifttt-workitem/pom.xml
+++ b/ifttt-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ifttt-workitem</artifactId>

--- a/ifttt-workitem/pom.xml
+++ b/ifttt-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ifttt-workitem</artifactId>

--- a/ifttt-workitem/pom.xml
+++ b/ifttt-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ifttt-workitem</artifactId>

--- a/ifttt-workitem/pom.xml
+++ b/ifttt-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ifttt-workitem</artifactId>

--- a/ifttt-workitem/pom.xml
+++ b/ifttt-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ifttt-workitem</artifactId>

--- a/ifttt-workitem/pom.xml
+++ b/ifttt-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ifttt-workitem</artifactId>

--- a/jabber-workitem/pom.xml
+++ b/jabber-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jabber-workitem</artifactId>

--- a/jabber-workitem/pom.xml
+++ b/jabber-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jabber-workitem</artifactId>

--- a/jabber-workitem/pom.xml
+++ b/jabber-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jabber-workitem</artifactId>

--- a/jabber-workitem/pom.xml
+++ b/jabber-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jabber-workitem</artifactId>

--- a/jabber-workitem/pom.xml
+++ b/jabber-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jabber-workitem</artifactId>

--- a/jabber-workitem/pom.xml
+++ b/jabber-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jabber-workitem</artifactId>

--- a/jabber-workitem/pom.xml
+++ b/jabber-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jabber-workitem</artifactId>

--- a/jabber-workitem/pom.xml
+++ b/jabber-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jabber-workitem</artifactId>

--- a/java-workitem/pom.xml
+++ b/java-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-workitem</artifactId>

--- a/java-workitem/pom.xml
+++ b/java-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-workitem</artifactId>

--- a/java-workitem/pom.xml
+++ b/java-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-workitem</artifactId>

--- a/java-workitem/pom.xml
+++ b/java-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-workitem</artifactId>

--- a/java-workitem/pom.xml
+++ b/java-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-workitem</artifactId>

--- a/java-workitem/pom.xml
+++ b/java-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-workitem</artifactId>

--- a/java-workitem/pom.xml
+++ b/java-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-workitem</artifactId>

--- a/java-workitem/pom.xml
+++ b/java-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-workitem</artifactId>

--- a/jbpm-workitem-itests/README.md
+++ b/jbpm-workitem-itests/README.md
@@ -24,7 +24,7 @@ Running the application
 Use following command to execute the project:
 
 ```
-java -jar target/jbpm-workitem-itests-7.73.0-SNAPSHOT.jar evaluation:evaluation:1.0.0-SNAPSHOT
+java -jar target/jbpm-workitem-itests-7.74.0-SNAPSHOT.jar evaluation:evaluation:1.0.0-SNAPSHOT
 ```
 
 last part is the kjar that you would like to deploy in GAV format: **groupId:artifactId:version**

--- a/jbpm-workitem-itests/README.md
+++ b/jbpm-workitem-itests/README.md
@@ -24,7 +24,7 @@ Running the application
 Use following command to execute the project:
 
 ```
-java -jar target/jbpm-workitem-itests-7.69.0-SNAPSHOT.jar evaluation:evaluation:1.0.0-SNAPSHOT
+java -jar target/jbpm-workitem-itests-7.70.0-SNAPSHOT.jar evaluation:evaluation:1.0.0-SNAPSHOT
 ```
 
 last part is the kjar that you would like to deploy in GAV format: **groupId:artifactId:version**

--- a/jbpm-workitem-itests/README.md
+++ b/jbpm-workitem-itests/README.md
@@ -24,7 +24,7 @@ Running the application
 Use following command to execute the project:
 
 ```
-java -jar target/jbpm-workitem-itests-7.72.0-SNAPSHOT.jar evaluation:evaluation:1.0.0-SNAPSHOT
+java -jar target/jbpm-workitem-itests-7.73.0-SNAPSHOT.jar evaluation:evaluation:1.0.0-SNAPSHOT
 ```
 
 last part is the kjar that you would like to deploy in GAV format: **groupId:artifactId:version**

--- a/jbpm-workitem-itests/README.md
+++ b/jbpm-workitem-itests/README.md
@@ -24,7 +24,7 @@ Running the application
 Use following command to execute the project:
 
 ```
-java -jar target/jbpm-workitem-itests-7.67.0-SNAPSHOT.jar evaluation:evaluation:1.0.0-SNAPSHOT
+java -jar target/jbpm-workitem-itests-7.68.0-SNAPSHOT.jar evaluation:evaluation:1.0.0-SNAPSHOT
 ```
 
 last part is the kjar that you would like to deploy in GAV format: **groupId:artifactId:version**

--- a/jbpm-workitem-itests/README.md
+++ b/jbpm-workitem-itests/README.md
@@ -24,7 +24,7 @@ Running the application
 Use following command to execute the project:
 
 ```
-java -jar target/jbpm-workitem-itests-7.70.0-SNAPSHOT.jar evaluation:evaluation:1.0.0-SNAPSHOT
+java -jar target/jbpm-workitem-itests-7.71.0-SNAPSHOT.jar evaluation:evaluation:1.0.0-SNAPSHOT
 ```
 
 last part is the kjar that you would like to deploy in GAV format: **groupId:artifactId:version**

--- a/jbpm-workitem-itests/README.md
+++ b/jbpm-workitem-itests/README.md
@@ -24,7 +24,7 @@ Running the application
 Use following command to execute the project:
 
 ```
-java -jar target/jbpm-workitem-itests-7.71.0-SNAPSHOT.jar evaluation:evaluation:1.0.0-SNAPSHOT
+java -jar target/jbpm-workitem-itests-7.72.0-SNAPSHOT.jar evaluation:evaluation:1.0.0-SNAPSHOT
 ```
 
 last part is the kjar that you would like to deploy in GAV format: **groupId:artifactId:version**

--- a/jbpm-workitem-itests/README.md
+++ b/jbpm-workitem-itests/README.md
@@ -24,7 +24,7 @@ Running the application
 Use following command to execute the project:
 
 ```
-java -jar target/jbpm-workitem-itests-7.74.0-SNAPSHOT.jar evaluation:evaluation:1.0.0-SNAPSHOT
+java -jar target/jbpm-workitem-itests-7.75.0-SNAPSHOT.jar evaluation:evaluation:1.0.0-SNAPSHOT
 ```
 
 last part is the kjar that you would like to deploy in GAV format: **groupId:artifactId:version**

--- a/jbpm-workitem-itests/README.md
+++ b/jbpm-workitem-itests/README.md
@@ -24,7 +24,7 @@ Running the application
 Use following command to execute the project:
 
 ```
-java -jar target/jbpm-workitem-itests-7.68.0-SNAPSHOT.jar evaluation:evaluation:1.0.0-SNAPSHOT
+java -jar target/jbpm-workitem-itests-7.69.0-SNAPSHOT.jar evaluation:evaluation:1.0.0-SNAPSHOT
 ```
 
 last part is the kjar that you would like to deploy in GAV format: **groupId:artifactId:version**

--- a/jbpm-workitem-itests/pom.xml
+++ b/jbpm-workitem-itests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-workitem-itests</artifactId>

--- a/jbpm-workitem-itests/pom.xml
+++ b/jbpm-workitem-itests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-workitem-itests</artifactId>

--- a/jbpm-workitem-itests/pom.xml
+++ b/jbpm-workitem-itests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-workitem-itests</artifactId>

--- a/jbpm-workitem-itests/pom.xml
+++ b/jbpm-workitem-itests/pom.xml
@@ -203,6 +203,7 @@
               <toxiproxy.image>shopify/toxiproxy:2.1.4</toxiproxy.image>
               <toxiproxy.port>9093</toxiproxy.port>
               <org.kie.executor.jms>false</org.kie.executor.jms>
+              <kafka.container.version>${version.org.apache.kafka}</kafka.container.version>
             </systemPropertyVariables>
           </configuration>
         </plugin>

--- a/jbpm-workitem-itests/pom.xml
+++ b/jbpm-workitem-itests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-workitem-itests</artifactId>

--- a/jbpm-workitem-itests/pom.xml
+++ b/jbpm-workitem-itests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-workitem-itests</artifactId>

--- a/jbpm-workitem-itests/pom.xml
+++ b/jbpm-workitem-itests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-workitem-itests</artifactId>

--- a/jbpm-workitem-itests/pom.xml
+++ b/jbpm-workitem-itests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-workitem-itests</artifactId>

--- a/jbpm-workitem-itests/pom.xml
+++ b/jbpm-workitem-itests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-workitem-itests</artifactId>

--- a/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaFixture.java
+++ b/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaFixture.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 
-import io.strimzi.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaContainer;
 
 import static java.util.Collections.singletonList;
 

--- a/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaProxyBase.java
+++ b/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaProxyBase.java
@@ -38,7 +38,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import io.strimzi.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaContainer;
 
 import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;
@@ -63,7 +63,9 @@ public abstract class KafkaProxyBase extends KafkaBaseTest {
     public Network network = Network.newNetwork();
 
     @Rule
-    public StrimziKafkaContainer kafka = new StrimziKafkaContainer().withNetwork(network);
+    public StrimziKafkaContainer kafka = new StrimziKafkaContainer()
+                                                .withKafkaVersion(System.getProperty("kafka.container.version"))
+                                                .withNetwork(network);
 
     @Rule
     public ToxiproxyContainer toxiproxy  = new ToxiproxyContainer(DockerImageName.parse(TOXIPROXY_IMAGE))

--- a/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaProxyBase.java
+++ b/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaProxyBase.java
@@ -17,6 +17,7 @@
 package org.jbpm.workitem.springboot.samples;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -53,6 +54,8 @@ public abstract class KafkaProxyBase extends KafkaBaseTest {
     
     protected static final int TOXY_PROXY_PORT = Integer.parseInt(System.getProperty("toxiproxy.port"));
     
+    private static final String VERSION = String.join(".", Arrays.copyOfRange(System.getProperty("kafka.container.version", "3.1.0").split("\\."), 0, 3));
+    
     @ClassRule
     public static final SpringClassRule scr = new SpringClassRule();
  
@@ -64,7 +67,7 @@ public abstract class KafkaProxyBase extends KafkaBaseTest {
 
     @Rule
     public StrimziKafkaContainer kafka = new StrimziKafkaContainer()
-                                                .withKafkaVersion(System.getProperty("kafka.container.version"))
+                                                .withKafkaVersion(VERSION)
                                                 .withNetwork(network);
 
     @Rule

--- a/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaSampleTest.java
+++ b/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaSampleTest.java
@@ -34,7 +34,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
-import io.strimzi.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaContainer;
 
 import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;

--- a/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaSerializationTest.java
+++ b/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaSerializationTest.java
@@ -34,7 +34,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
-import io.strimzi.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaContainer;
 
 import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;

--- a/jbpm-workitem-itests/src/test/resources/application-test-async.properties
+++ b/jbpm-workitem-itests/src/test/resources/application-test-async.properties
@@ -8,6 +8,9 @@ server.port=8090
 spring.jpa.properties.hibernate.hbm2ddl.auto=create
 spring.jpa.properties.hibernate.show_sql=false
 
+#override datasource url to skip VALUE as a keyword for embedded h2
+spring.datasource.url=jdbc:h2:mem:jbpm-db;MODE=LEGACY;NON_KEYWORDS=VALUE
+
 # Taken from https://docs.spring.io/spring-boot/docs/2.4.0-M2/reference/htmlsingle/#common-application-properties
 # Used in Kafka tests where publish blocking connection timeout (max.block.ms) is 60 seconds, same as default 
 # transaction timeout for nayarana. If this timeout is not increased, following exception is raised:

--- a/jbpm-workitem-itests/src/test/resources/application-test.properties
+++ b/jbpm-workitem-itests/src/test/resources/application-test.properties
@@ -8,6 +8,10 @@ server.port=8090
 spring.jpa.properties.hibernate.hbm2ddl.auto=create
 spring.jpa.properties.hibernate.show_sql=false
 
+
+#override datasource url to skip VALUE as a keyword for embedded h2
+spring.datasource.url=jdbc:h2:mem:jbpm-db;MODE=LEGACY;NON_KEYWORDS=VALUE
+
 # Taken from https://docs.spring.io/spring-boot/docs/2.4.0-M2/reference/htmlsingle/#common-application-properties
 # Used in Kafka tests where publish blocking connection timeout (max.block.ms) is 60 seconds, same as default 
 # transaction timeout for nayarana. If this timeout is not increased, following exception is raised:

--- a/jira-workitem/pom.xml
+++ b/jira-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jira-workitem</artifactId>

--- a/jira-workitem/pom.xml
+++ b/jira-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jira-workitem</artifactId>

--- a/jira-workitem/pom.xml
+++ b/jira-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jira-workitem</artifactId>

--- a/jira-workitem/pom.xml
+++ b/jira-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jira-workitem</artifactId>

--- a/jira-workitem/pom.xml
+++ b/jira-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jira-workitem</artifactId>

--- a/jira-workitem/pom.xml
+++ b/jira-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jira-workitem</artifactId>

--- a/jira-workitem/pom.xml
+++ b/jira-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jira-workitem</artifactId>

--- a/jira-workitem/pom.xml
+++ b/jira-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jira-workitem</artifactId>

--- a/jpa-workitem/pom.xml
+++ b/jpa-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jpa-workitem</artifactId>

--- a/jpa-workitem/pom.xml
+++ b/jpa-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jpa-workitem</artifactId>

--- a/jpa-workitem/pom.xml
+++ b/jpa-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jpa-workitem</artifactId>

--- a/jpa-workitem/pom.xml
+++ b/jpa-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jpa-workitem</artifactId>

--- a/jpa-workitem/pom.xml
+++ b/jpa-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jpa-workitem</artifactId>

--- a/jpa-workitem/pom.xml
+++ b/jpa-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jpa-workitem</artifactId>

--- a/jpa-workitem/pom.xml
+++ b/jpa-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jpa-workitem</artifactId>

--- a/jpa-workitem/pom.xml
+++ b/jpa-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jpa-workitem</artifactId>

--- a/jpa-workitem/src/test/java/org/jbpm/process/workitem/jpa/JPAWorkItemHandlerTest.java
+++ b/jpa-workitem/src/test/java/org/jbpm/process/workitem/jpa/JPAWorkItemHandlerTest.java
@@ -356,7 +356,7 @@ public class JPAWorkItemHandlerTest {
         driverProperties.setProperty("password",
                                      "sa");
         driverProperties.setProperty("url",
-                                     "jdbc:h2:mem:jpa-wih;MVCC=true");
+                                     "jdbc:h2:mem:jpa-wih;MODE=LEGACY;NON_KEYWORDS=VALUE");
         driverProperties.setProperty("driverClassName",
                                      "org.h2.Driver");
 
@@ -373,7 +373,7 @@ public class JPAWorkItemHandlerTest {
         public void start() {
             if (realH2Server == null || !realH2Server.isRunning(false)) {
                 try {
-                    realH2Server = Server.createTcpServer(new String[0]);
+                    realH2Server = Server.createTcpServer(new String[]{"-ifNotExists"});
                     realH2Server.start();
                     System.out.println("Started H2 Server...");
                 } catch (SQLException e) {

--- a/kafka-workitem/pom.xml
+++ b/kafka-workitem/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
   <artifactId>kafka-workitem</artifactId>
   <name>Kafka</name>

--- a/kafka-workitem/pom.xml
+++ b/kafka-workitem/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
   <artifactId>kafka-workitem</artifactId>
   <name>Kafka</name>

--- a/kafka-workitem/pom.xml
+++ b/kafka-workitem/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
   <artifactId>kafka-workitem</artifactId>
   <name>Kafka</name>

--- a/kafka-workitem/pom.xml
+++ b/kafka-workitem/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
   <artifactId>kafka-workitem</artifactId>
   <name>Kafka</name>

--- a/kafka-workitem/pom.xml
+++ b/kafka-workitem/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
   <artifactId>kafka-workitem</artifactId>
   <name>Kafka</name>

--- a/kafka-workitem/pom.xml
+++ b/kafka-workitem/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
   <artifactId>kafka-workitem</artifactId>
   <name>Kafka</name>

--- a/kafka-workitem/pom.xml
+++ b/kafka-workitem/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
   <artifactId>kafka-workitem</artifactId>
   <name>Kafka</name>

--- a/kafka-workitem/pom.xml
+++ b/kafka-workitem/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
   <artifactId>kafka-workitem</artifactId>
   <name>Kafka</name>

--- a/karaf-itests/pom.xml
+++ b/karaf-itests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>workitems</artifactId>
     <groupId>org.jbpm.contrib</groupId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/karaf-itests/pom.xml
+++ b/karaf-itests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>workitems</artifactId>
     <groupId>org.jbpm.contrib</groupId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/karaf-itests/pom.xml
+++ b/karaf-itests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>workitems</artifactId>
     <groupId>org.jbpm.contrib</groupId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/karaf-itests/pom.xml
+++ b/karaf-itests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>workitems</artifactId>
     <groupId>org.jbpm.contrib</groupId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/karaf-itests/pom.xml
+++ b/karaf-itests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>workitems</artifactId>
     <groupId>org.jbpm.contrib</groupId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/karaf-itests/pom.xml
+++ b/karaf-itests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>workitems</artifactId>
     <groupId>org.jbpm.contrib</groupId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/karaf-itests/pom.xml
+++ b/karaf-itests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>workitems</artifactId>
     <groupId>org.jbpm.contrib</groupId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/karaf-itests/pom.xml
+++ b/karaf-itests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>workitems</artifactId>
     <groupId>org.jbpm.contrib</groupId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/long-running-rest-workitem/pom.xml
+++ b/long-running-rest-workitem/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>long-running-rest-workitem</artifactId>

--- a/long-running-rest-workitem/pom.xml
+++ b/long-running-rest-workitem/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>long-running-rest-workitem</artifactId>

--- a/long-running-rest-workitem/pom.xml
+++ b/long-running-rest-workitem/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>long-running-rest-workitem</artifactId>

--- a/long-running-rest-workitem/pom.xml
+++ b/long-running-rest-workitem/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>long-running-rest-workitem</artifactId>

--- a/long-running-rest-workitem/pom.xml
+++ b/long-running-rest-workitem/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>long-running-rest-workitem</artifactId>

--- a/long-running-rest-workitem/pom.xml
+++ b/long-running-rest-workitem/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>long-running-rest-workitem</artifactId>

--- a/long-running-rest-workitem/pom.xml
+++ b/long-running-rest-workitem/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>long-running-rest-workitem</artifactId>

--- a/long-running-rest-workitem/pom.xml
+++ b/long-running-rest-workitem/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>long-running-rest-workitem</artifactId>

--- a/mavenembedder-workitem/pom.xml
+++ b/mavenembedder-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>mavenembedder-workitem</artifactId>

--- a/mavenembedder-workitem/pom.xml
+++ b/mavenembedder-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>mavenembedder-workitem</artifactId>

--- a/mavenembedder-workitem/pom.xml
+++ b/mavenembedder-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>mavenembedder-workitem</artifactId>

--- a/mavenembedder-workitem/pom.xml
+++ b/mavenembedder-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>mavenembedder-workitem</artifactId>

--- a/mavenembedder-workitem/pom.xml
+++ b/mavenembedder-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>mavenembedder-workitem</artifactId>

--- a/mavenembedder-workitem/pom.xml
+++ b/mavenembedder-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>mavenembedder-workitem</artifactId>

--- a/mavenembedder-workitem/pom.xml
+++ b/mavenembedder-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>mavenembedder-workitem</artifactId>

--- a/mavenembedder-workitem/pom.xml
+++ b/mavenembedder-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>mavenembedder-workitem</artifactId>

--- a/okta-workitem/pom.xml
+++ b/okta-workitem/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
   <artifactId>okta-workitem</artifactId>
   <name>Okta</name>

--- a/okta-workitem/pom.xml
+++ b/okta-workitem/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
   <artifactId>okta-workitem</artifactId>
   <name>Okta</name>

--- a/okta-workitem/pom.xml
+++ b/okta-workitem/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
   <artifactId>okta-workitem</artifactId>
   <name>Okta</name>

--- a/okta-workitem/pom.xml
+++ b/okta-workitem/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
   <artifactId>okta-workitem</artifactId>
   <name>Okta</name>

--- a/okta-workitem/pom.xml
+++ b/okta-workitem/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
   <artifactId>okta-workitem</artifactId>
   <name>Okta</name>

--- a/okta-workitem/pom.xml
+++ b/okta-workitem/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
   <artifactId>okta-workitem</artifactId>
   <name>Okta</name>

--- a/okta-workitem/pom.xml
+++ b/okta-workitem/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
   <artifactId>okta-workitem</artifactId>
   <name>Okta</name>

--- a/okta-workitem/pom.xml
+++ b/okta-workitem/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
   <artifactId>okta-workitem</artifactId>
   <name>Okta</name>

--- a/openweathermap-workitem/pom.xml
+++ b/openweathermap-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>openweathermap-workitem</artifactId>

--- a/openweathermap-workitem/pom.xml
+++ b/openweathermap-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>openweathermap-workitem</artifactId>

--- a/openweathermap-workitem/pom.xml
+++ b/openweathermap-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>openweathermap-workitem</artifactId>

--- a/openweathermap-workitem/pom.xml
+++ b/openweathermap-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>openweathermap-workitem</artifactId>

--- a/openweathermap-workitem/pom.xml
+++ b/openweathermap-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>openweathermap-workitem</artifactId>

--- a/openweathermap-workitem/pom.xml
+++ b/openweathermap-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>openweathermap-workitem</artifactId>

--- a/openweathermap-workitem/pom.xml
+++ b/openweathermap-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>openweathermap-workitem</artifactId>

--- a/openweathermap-workitem/pom.xml
+++ b/openweathermap-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>openweathermap-workitem</artifactId>

--- a/parser-workitem/pom.xml
+++ b/parser-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>parser-workitem</artifactId>

--- a/parser-workitem/pom.xml
+++ b/parser-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>parser-workitem</artifactId>

--- a/parser-workitem/pom.xml
+++ b/parser-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>parser-workitem</artifactId>

--- a/parser-workitem/pom.xml
+++ b/parser-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>parser-workitem</artifactId>

--- a/parser-workitem/pom.xml
+++ b/parser-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>parser-workitem</artifactId>

--- a/parser-workitem/pom.xml
+++ b/parser-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>parser-workitem</artifactId>

--- a/parser-workitem/pom.xml
+++ b/parser-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>parser-workitem</artifactId>

--- a/parser-workitem/pom.xml
+++ b/parser-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>parser-workitem</artifactId>

--- a/pastebin-workitem/pom.xml
+++ b/pastebin-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pastebin-workitem</artifactId>

--- a/pastebin-workitem/pom.xml
+++ b/pastebin-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pastebin-workitem</artifactId>

--- a/pastebin-workitem/pom.xml
+++ b/pastebin-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pastebin-workitem</artifactId>

--- a/pastebin-workitem/pom.xml
+++ b/pastebin-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pastebin-workitem</artifactId>

--- a/pastebin-workitem/pom.xml
+++ b/pastebin-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pastebin-workitem</artifactId>

--- a/pastebin-workitem/pom.xml
+++ b/pastebin-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pastebin-workitem</artifactId>

--- a/pastebin-workitem/pom.xml
+++ b/pastebin-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pastebin-workitem</artifactId>

--- a/pastebin-workitem/pom.xml
+++ b/pastebin-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pastebin-workitem</artifactId>

--- a/pdf-workitem/pom.xml
+++ b/pdf-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pdf-workitem</artifactId>

--- a/pdf-workitem/pom.xml
+++ b/pdf-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pdf-workitem</artifactId>

--- a/pdf-workitem/pom.xml
+++ b/pdf-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pdf-workitem</artifactId>

--- a/pdf-workitem/pom.xml
+++ b/pdf-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pdf-workitem</artifactId>

--- a/pdf-workitem/pom.xml
+++ b/pdf-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pdf-workitem</artifactId>

--- a/pdf-workitem/pom.xml
+++ b/pdf-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pdf-workitem</artifactId>

--- a/pdf-workitem/pom.xml
+++ b/pdf-workitem/pom.xml
@@ -39,11 +39,11 @@
     <!-- needed for itext optional depends -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk15to18</artifactId>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk15to18</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.santuario</groupId>

--- a/pdf-workitem/pom.xml
+++ b/pdf-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pdf-workitem</artifactId>

--- a/pdf-workitem/pom.xml
+++ b/pdf-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pdf-workitem</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-parent</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.jbpm.contrib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-parent</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.jbpm.contrib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-parent</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.jbpm.contrib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <maven.jdbc.driver.jar/>
     <maven.jdbc.username>sa</maven.jdbc.username>
     <maven.jdbc.password>sasa</maven.jdbc.password>
-    <maven.jdbc.url>jdbc:h2:tcp://localhost/${project.basedir}/target/jbpm-test;MVCC=TRUE</maven.jdbc.url>
+    <maven.jdbc.url>jdbc:h2:tcp://localhost/${project.basedir}/target/jbpm-test;MODE=LEGACY;NON_KEYWORDS=VALUE</maven.jdbc.url>
     <maven.jdbc.schema>public</maven.jdbc.schema>
 
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-parent</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.jbpm.contrib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-parent</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.jbpm.contrib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <version.atlassian.jira>1.0</version.atlassian.jira>
     <version.web3j>3.3.1</version.web3j>
     <version.github.jnr>0.15</version.github.jnr>
-    <version.squareup.okhttp3>3.8.1</version.squareup.okhttp3>
+    <version.squareup.okhttp3>3.12.12</version.squareup.okhttp3>
     <version.rxjava>1.2.4</version.rxjava>
     <version.owm>2.5.2.2</version.owm>
     <version.commons.net>3.6</version.commons.net>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-parent</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.jbpm.contrib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -340,12 +340,12 @@
 
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on</artifactId>
+        <artifactId>bcprov-jdk15to18</artifactId>
         <version>${version.bouncycastle}</version>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
+        <artifactId>bcpkix-jdk15to18</artifactId>
         <version>${version.bouncycastle}</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-parent</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.jbpm.contrib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-parent</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.jbpm.contrib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,11 @@
         <version>${version.docker-java}</version>
       </dependency>
       <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http</artifactId>
+        <version>4.1.129.Final</version>
+      </dependency>
+      <dependency>
         <groupId>org.web3j</groupId>
         <artifactId>core</artifactId>
         <version>${version.web3j}</version>

--- a/repository-springboot/pom.xml
+++ b/repository-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository-springboot</artifactId>

--- a/repository-springboot/pom.xml
+++ b/repository-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository-springboot</artifactId>

--- a/repository-springboot/pom.xml
+++ b/repository-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository-springboot</artifactId>

--- a/repository-springboot/pom.xml
+++ b/repository-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository-springboot</artifactId>

--- a/repository-springboot/pom.xml
+++ b/repository-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository-springboot</artifactId>

--- a/repository-springboot/pom.xml
+++ b/repository-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository-springboot</artifactId>

--- a/repository-springboot/pom.xml
+++ b/repository-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository-springboot</artifactId>

--- a/repository-springboot/pom.xml
+++ b/repository-springboot/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository-springboot</artifactId>

--- a/repository-wildfly/pom.xml
+++ b/repository-wildfly/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository-wildfly</artifactId>

--- a/repository-wildfly/pom.xml
+++ b/repository-wildfly/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository-wildfly</artifactId>

--- a/repository-wildfly/pom.xml
+++ b/repository-wildfly/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository-wildfly</artifactId>

--- a/repository-wildfly/pom.xml
+++ b/repository-wildfly/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository-wildfly</artifactId>

--- a/repository-wildfly/pom.xml
+++ b/repository-wildfly/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository-wildfly</artifactId>

--- a/repository-wildfly/pom.xml
+++ b/repository-wildfly/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository-wildfly</artifactId>

--- a/repository-wildfly/pom.xml
+++ b/repository-wildfly/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository-wildfly</artifactId>

--- a/repository-wildfly/pom.xml
+++ b/repository-wildfly/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository-wildfly</artifactId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository</artifactId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository</artifactId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository</artifactId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository</artifactId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository</artifactId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository</artifactId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository</artifactId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>repository</artifactId>

--- a/repository/src/test/java/org/jbpm/process/workitem/repository/service/RepoServiceIntegrationTest.java
+++ b/repository/src/test/java/org/jbpm/process/workitem/repository/service/RepoServiceIntegrationTest.java
@@ -134,7 +134,7 @@ public class RepoServiceIntegrationTest {
 
     @Test
     public void testAddServiceTask(){
-        RepoData addService = initRepoData(VIMEO_NEW, "7.67.0-SNAPSHOT");
+        RepoData addService = initRepoData(VIMEO_NEW, "7.68.0-SNAPSHOT");
         HashMap<String, List<String>> resultMap = new HashMap<>();
         repoService.addService(addService, resultMap);
         addService.setId(UUID.randomUUID().toString());
@@ -142,7 +142,7 @@ public class RepoServiceIntegrationTest {
         assertEquals(VIMEO_NEW, resultMap.get(RepoService.CREATED).get(0));
 
 
-        RepoData updateService = initRepoData(VIMEO_NEW, "7.67.0-SNAPSHOT");
+        RepoData updateService = initRepoData(VIMEO_NEW, "7.68.0-SNAPSHOT");
         resultMap.clear();
         updateService.setId(UUID.randomUUID().toString());
         repoService.addService(updateService, resultMap);

--- a/repository/src/test/java/org/jbpm/process/workitem/repository/service/RepoServiceIntegrationTest.java
+++ b/repository/src/test/java/org/jbpm/process/workitem/repository/service/RepoServiceIntegrationTest.java
@@ -134,7 +134,7 @@ public class RepoServiceIntegrationTest {
 
     @Test
     public void testAddServiceTask(){
-        RepoData addService = initRepoData(VIMEO_NEW, "7.73.0-SNAPSHOT");
+        RepoData addService = initRepoData(VIMEO_NEW, "7.74.0-SNAPSHOT");
         HashMap<String, List<String>> resultMap = new HashMap<>();
         repoService.addService(addService, resultMap);
         addService.setId(UUID.randomUUID().toString());
@@ -142,7 +142,7 @@ public class RepoServiceIntegrationTest {
         assertEquals(VIMEO_NEW, resultMap.get(RepoService.CREATED).get(0));
 
 
-        RepoData updateService = initRepoData(VIMEO_NEW, "7.73.0-SNAPSHOT");
+        RepoData updateService = initRepoData(VIMEO_NEW, "7.74.0-SNAPSHOT");
         resultMap.clear();
         updateService.setId(UUID.randomUUID().toString());
         repoService.addService(updateService, resultMap);

--- a/repository/src/test/java/org/jbpm/process/workitem/repository/service/RepoServiceIntegrationTest.java
+++ b/repository/src/test/java/org/jbpm/process/workitem/repository/service/RepoServiceIntegrationTest.java
@@ -134,7 +134,7 @@ public class RepoServiceIntegrationTest {
 
     @Test
     public void testAddServiceTask(){
-        RepoData addService = initRepoData(VIMEO_NEW, "7.69.0-SNAPSHOT");
+        RepoData addService = initRepoData(VIMEO_NEW, "7.70.0-SNAPSHOT");
         HashMap<String, List<String>> resultMap = new HashMap<>();
         repoService.addService(addService, resultMap);
         addService.setId(UUID.randomUUID().toString());
@@ -142,7 +142,7 @@ public class RepoServiceIntegrationTest {
         assertEquals(VIMEO_NEW, resultMap.get(RepoService.CREATED).get(0));
 
 
-        RepoData updateService = initRepoData(VIMEO_NEW, "7.69.0-SNAPSHOT");
+        RepoData updateService = initRepoData(VIMEO_NEW, "7.70.0-SNAPSHOT");
         resultMap.clear();
         updateService.setId(UUID.randomUUID().toString());
         repoService.addService(updateService, resultMap);

--- a/repository/src/test/java/org/jbpm/process/workitem/repository/service/RepoServiceIntegrationTest.java
+++ b/repository/src/test/java/org/jbpm/process/workitem/repository/service/RepoServiceIntegrationTest.java
@@ -134,7 +134,7 @@ public class RepoServiceIntegrationTest {
 
     @Test
     public void testAddServiceTask(){
-        RepoData addService = initRepoData(VIMEO_NEW, "7.71.0-SNAPSHOT");
+        RepoData addService = initRepoData(VIMEO_NEW, "7.72.0-SNAPSHOT");
         HashMap<String, List<String>> resultMap = new HashMap<>();
         repoService.addService(addService, resultMap);
         addService.setId(UUID.randomUUID().toString());
@@ -142,7 +142,7 @@ public class RepoServiceIntegrationTest {
         assertEquals(VIMEO_NEW, resultMap.get(RepoService.CREATED).get(0));
 
 
-        RepoData updateService = initRepoData(VIMEO_NEW, "7.71.0-SNAPSHOT");
+        RepoData updateService = initRepoData(VIMEO_NEW, "7.72.0-SNAPSHOT");
         resultMap.clear();
         updateService.setId(UUID.randomUUID().toString());
         repoService.addService(updateService, resultMap);

--- a/repository/src/test/java/org/jbpm/process/workitem/repository/service/RepoServiceIntegrationTest.java
+++ b/repository/src/test/java/org/jbpm/process/workitem/repository/service/RepoServiceIntegrationTest.java
@@ -134,7 +134,7 @@ public class RepoServiceIntegrationTest {
 
     @Test
     public void testAddServiceTask(){
-        RepoData addService = initRepoData(VIMEO_NEW, "7.74.0-SNAPSHOT");
+        RepoData addService = initRepoData(VIMEO_NEW, "7.75.0-SNAPSHOT");
         HashMap<String, List<String>> resultMap = new HashMap<>();
         repoService.addService(addService, resultMap);
         addService.setId(UUID.randomUUID().toString());
@@ -142,7 +142,7 @@ public class RepoServiceIntegrationTest {
         assertEquals(VIMEO_NEW, resultMap.get(RepoService.CREATED).get(0));
 
 
-        RepoData updateService = initRepoData(VIMEO_NEW, "7.74.0-SNAPSHOT");
+        RepoData updateService = initRepoData(VIMEO_NEW, "7.75.0-SNAPSHOT");
         resultMap.clear();
         updateService.setId(UUID.randomUUID().toString());
         repoService.addService(updateService, resultMap);

--- a/repository/src/test/java/org/jbpm/process/workitem/repository/service/RepoServiceIntegrationTest.java
+++ b/repository/src/test/java/org/jbpm/process/workitem/repository/service/RepoServiceIntegrationTest.java
@@ -134,7 +134,7 @@ public class RepoServiceIntegrationTest {
 
     @Test
     public void testAddServiceTask(){
-        RepoData addService = initRepoData(VIMEO_NEW, "7.72.0-SNAPSHOT");
+        RepoData addService = initRepoData(VIMEO_NEW, "7.73.0-SNAPSHOT");
         HashMap<String, List<String>> resultMap = new HashMap<>();
         repoService.addService(addService, resultMap);
         addService.setId(UUID.randomUUID().toString());
@@ -142,7 +142,7 @@ public class RepoServiceIntegrationTest {
         assertEquals(VIMEO_NEW, resultMap.get(RepoService.CREATED).get(0));
 
 
-        RepoData updateService = initRepoData(VIMEO_NEW, "7.72.0-SNAPSHOT");
+        RepoData updateService = initRepoData(VIMEO_NEW, "7.73.0-SNAPSHOT");
         resultMap.clear();
         updateService.setId(UUID.randomUUID().toString());
         repoService.addService(updateService, resultMap);

--- a/repository/src/test/java/org/jbpm/process/workitem/repository/service/RepoServiceIntegrationTest.java
+++ b/repository/src/test/java/org/jbpm/process/workitem/repository/service/RepoServiceIntegrationTest.java
@@ -134,7 +134,7 @@ public class RepoServiceIntegrationTest {
 
     @Test
     public void testAddServiceTask(){
-        RepoData addService = initRepoData(VIMEO_NEW, "7.68.0-SNAPSHOT");
+        RepoData addService = initRepoData(VIMEO_NEW, "7.69.0-SNAPSHOT");
         HashMap<String, List<String>> resultMap = new HashMap<>();
         repoService.addService(addService, resultMap);
         addService.setId(UUID.randomUUID().toString());
@@ -142,7 +142,7 @@ public class RepoServiceIntegrationTest {
         assertEquals(VIMEO_NEW, resultMap.get(RepoService.CREATED).get(0));
 
 
-        RepoData updateService = initRepoData(VIMEO_NEW, "7.68.0-SNAPSHOT");
+        RepoData updateService = initRepoData(VIMEO_NEW, "7.69.0-SNAPSHOT");
         resultMap.clear();
         updateService.setId(UUID.randomUUID().toString());
         repoService.addService(updateService, resultMap);

--- a/repository/src/test/java/org/jbpm/process/workitem/repository/service/RepoServiceIntegrationTest.java
+++ b/repository/src/test/java/org/jbpm/process/workitem/repository/service/RepoServiceIntegrationTest.java
@@ -134,7 +134,7 @@ public class RepoServiceIntegrationTest {
 
     @Test
     public void testAddServiceTask(){
-        RepoData addService = initRepoData(VIMEO_NEW, "7.70.0-SNAPSHOT");
+        RepoData addService = initRepoData(VIMEO_NEW, "7.71.0-SNAPSHOT");
         HashMap<String, List<String>> resultMap = new HashMap<>();
         repoService.addService(addService, resultMap);
         addService.setId(UUID.randomUUID().toString());
@@ -142,7 +142,7 @@ public class RepoServiceIntegrationTest {
         assertEquals(VIMEO_NEW, resultMap.get(RepoService.CREATED).get(0));
 
 
-        RepoData updateService = initRepoData(VIMEO_NEW, "7.70.0-SNAPSHOT");
+        RepoData updateService = initRepoData(VIMEO_NEW, "7.71.0-SNAPSHOT");
         resultMap.clear();
         updateService.setId(UUID.randomUUID().toString());
         repoService.addService(updateService, resultMap);

--- a/riot-workitem/pom.xml
+++ b/riot-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>riot-workitem</artifactId>

--- a/riot-workitem/pom.xml
+++ b/riot-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>riot-workitem</artifactId>

--- a/riot-workitem/pom.xml
+++ b/riot-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>riot-workitem</artifactId>

--- a/riot-workitem/pom.xml
+++ b/riot-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>riot-workitem</artifactId>

--- a/riot-workitem/pom.xml
+++ b/riot-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>riot-workitem</artifactId>

--- a/riot-workitem/pom.xml
+++ b/riot-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>riot-workitem</artifactId>

--- a/riot-workitem/pom.xml
+++ b/riot-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>riot-workitem</artifactId>

--- a/riot-workitem/pom.xml
+++ b/riot-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>riot-workitem</artifactId>

--- a/rss-workitem/pom.xml
+++ b/rss-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>rss-workitem</artifactId>

--- a/rss-workitem/pom.xml
+++ b/rss-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>rss-workitem</artifactId>

--- a/rss-workitem/pom.xml
+++ b/rss-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>rss-workitem</artifactId>

--- a/rss-workitem/pom.xml
+++ b/rss-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>rss-workitem</artifactId>

--- a/rss-workitem/pom.xml
+++ b/rss-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>rss-workitem</artifactId>

--- a/rss-workitem/pom.xml
+++ b/rss-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>rss-workitem</artifactId>

--- a/rss-workitem/pom.xml
+++ b/rss-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>rss-workitem</artifactId>

--- a/rss-workitem/pom.xml
+++ b/rss-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>rss-workitem</artifactId>

--- a/slack-workitem/pom.xml
+++ b/slack-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>slack-workitem</artifactId>

--- a/slack-workitem/pom.xml
+++ b/slack-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>slack-workitem</artifactId>

--- a/slack-workitem/pom.xml
+++ b/slack-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>slack-workitem</artifactId>

--- a/slack-workitem/pom.xml
+++ b/slack-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>slack-workitem</artifactId>

--- a/slack-workitem/pom.xml
+++ b/slack-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>slack-workitem</artifactId>

--- a/slack-workitem/pom.xml
+++ b/slack-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>slack-workitem</artifactId>

--- a/slack-workitem/pom.xml
+++ b/slack-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>slack-workitem</artifactId>

--- a/slack-workitem/pom.xml
+++ b/slack-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>slack-workitem</artifactId>

--- a/template-resources/pom.xml
+++ b/template-resources/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>template-resources</artifactId>

--- a/template-resources/pom.xml
+++ b/template-resources/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>template-resources</artifactId>

--- a/template-resources/pom.xml
+++ b/template-resources/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>template-resources</artifactId>

--- a/template-resources/pom.xml
+++ b/template-resources/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>template-resources</artifactId>

--- a/template-resources/pom.xml
+++ b/template-resources/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>template-resources</artifactId>

--- a/template-resources/pom.xml
+++ b/template-resources/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>template-resources</artifactId>

--- a/template-resources/pom.xml
+++ b/template-resources/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>template-resources</artifactId>

--- a/template-resources/pom.xml
+++ b/template-resources/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>template-resources</artifactId>

--- a/transform-workitem/pom.xml
+++ b/transform-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>transform-workitem</artifactId>

--- a/transform-workitem/pom.xml
+++ b/transform-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>transform-workitem</artifactId>

--- a/transform-workitem/pom.xml
+++ b/transform-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>transform-workitem</artifactId>

--- a/transform-workitem/pom.xml
+++ b/transform-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>transform-workitem</artifactId>

--- a/transform-workitem/pom.xml
+++ b/transform-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>transform-workitem</artifactId>

--- a/transform-workitem/pom.xml
+++ b/transform-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>transform-workitem</artifactId>

--- a/transform-workitem/pom.xml
+++ b/transform-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>transform-workitem</artifactId>

--- a/transform-workitem/pom.xml
+++ b/transform-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>transform-workitem</artifactId>

--- a/twitter-workitem/pom.xml
+++ b/twitter-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>twitter-workitem</artifactId>

--- a/twitter-workitem/pom.xml
+++ b/twitter-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>twitter-workitem</artifactId>

--- a/twitter-workitem/pom.xml
+++ b/twitter-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>twitter-workitem</artifactId>

--- a/twitter-workitem/pom.xml
+++ b/twitter-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>twitter-workitem</artifactId>

--- a/twitter-workitem/pom.xml
+++ b/twitter-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>twitter-workitem</artifactId>

--- a/twitter-workitem/pom.xml
+++ b/twitter-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>twitter-workitem</artifactId>

--- a/twitter-workitem/pom.xml
+++ b/twitter-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>twitter-workitem</artifactId>

--- a/twitter-workitem/pom.xml
+++ b/twitter-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>twitter-workitem</artifactId>

--- a/vimeo-workitem/pom.xml
+++ b/vimeo-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.72.0-SNAPSHOT</version>
+    <version>7.73.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>vimeo-workitem</artifactId>

--- a/vimeo-workitem/pom.xml
+++ b/vimeo-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.74.0-SNAPSHOT</version>
+    <version>7.75.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>vimeo-workitem</artifactId>

--- a/vimeo-workitem/pom.xml
+++ b/vimeo-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.69.0-SNAPSHOT</version>
+    <version>7.70.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>vimeo-workitem</artifactId>

--- a/vimeo-workitem/pom.xml
+++ b/vimeo-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.70.0-SNAPSHOT</version>
+    <version>7.71.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>vimeo-workitem</artifactId>

--- a/vimeo-workitem/pom.xml
+++ b/vimeo-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.67.0-SNAPSHOT</version>
+    <version>7.68.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>vimeo-workitem</artifactId>

--- a/vimeo-workitem/pom.xml
+++ b/vimeo-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.69.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>vimeo-workitem</artifactId>

--- a/vimeo-workitem/pom.xml
+++ b/vimeo-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.73.0-SNAPSHOT</version>
+    <version>7.74.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>vimeo-workitem</artifactId>

--- a/vimeo-workitem/pom.xml
+++ b/vimeo-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm.contrib</groupId>
     <artifactId>workitems</artifactId>
-    <version>7.71.0-SNAPSHOT</version>
+    <version>7.72.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>vimeo-workitem</artifactId>


### PR DESCRIPTION
Fixes https://jsw.ibm.com/browse/DBACLD-199586
Fix CVE vulnerability in netty-codec-http from docker-java transitive dependency