### PR TITLE
Dbacld 199586 CVE fix

### DIFF
--- a/docker-workitem/pom.xml
+++ b/docker-workitem/pom.xml
@@ -33,11 +33,12 @@
           <groupId>org.bouncycastle</groupId>
           <artifactId>bcpkix-jdk15on</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>com.github.docker-java</groupId>
-          <artifactId>docker-java-transport-netty</artifactId>
-        </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-transport-netty</artifactId>
     </dependency>
 
     <dependency>

--- a/docker-workitem/pom.xml
+++ b/docker-workitem/pom.xml
@@ -33,6 +33,10 @@
           <groupId>org.bouncycastle</groupId>
           <artifactId>bcpkix-jdk15on</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.github.docker-java</groupId>
+          <artifactId>docker-java-transport-netty</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
     <version.google.maps>0.9.0</version.google.maps>
     <version.okta>1.3.0</version.okta>
     <version.docker-java>3.4.2</version.docker-java>
+    <version.netty>4.1.129.Final</version.netty>
     <!-- OSGI tests properties -->
     <version.org.apache.karaf>4.2.0</version.org.apache.karaf>
     <version.org.ops4j.pax.exam>4.13.4</version.org.ops4j.pax.exam>
@@ -264,6 +265,26 @@
         <groupId>com.github.docker-java</groupId>
         <artifactId>docker-java</artifactId>
         <version>${version.docker-java}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.docker-java</groupId>
+        <artifactId>docker-java-transport-netty</artifactId>
+        <version>${version.docker-java}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http</artifactId>
+        <version>${version.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${version.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport</artifactId>
+        <version>${version.netty}</version>
       </dependency>
       <dependency>
         <groupId>org.web3j</groupId>


### PR DESCRIPTION
Fixes https://jsw.ibm.com/browse/DBACLD-199586
Fix CVE vulnerability in netty-codec-http from docker-java transitive dependency