### PR TITLE
Fix CVE-2025-58057, CVE-2025-58056, CVE-2025-55163 using netty-bom

### DIFF
--- a/docker-workitem/pom.xml
+++ b/docker-workitem/pom.xml
@@ -37,6 +37,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-transport-netty</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-document</artifactId>
       <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
     <version.google.maps>0.9.0</version.google.maps>
     <version.okta>1.3.0</version.okta>
     <version.docker-java>3.4.2</version.docker-java>
+    <version.netty>4.1.128.Final</version.netty>
     <!-- OSGI tests properties -->
     <version.org.apache.karaf>4.2.0</version.org.apache.karaf>
     <version.org.ops4j.pax.exam>4.13.4</version.org.ops4j.pax.exam>
@@ -100,6 +101,14 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Import netty-bom to fix CVE-2025-58057, CVE-2025-58056, CVE-2025-55163 -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${version.netty}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.drools</groupId>
         <artifactId>drools-core</artifactId>
@@ -263,6 +272,11 @@
       <dependency>
         <groupId>com.github.docker-java</groupId>
         <artifactId>docker-java</artifactId>
+        <version>${version.docker-java}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.docker-java</groupId>
+        <artifactId>docker-java-transport-netty</artifactId>
         <version>${version.docker-java}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Fixes netty vulnerabilities in docker-workitem module by upgrading to netty 4.1.128.Final.
Add version.netty=4.1.128.Final property
Import netty-bom in dependencyManagement for complete coverage
Add `docker-java-transport-netty` dependency to docker-workitem

Ensemble PR: kiegroup/process-migration-service#143
