### PR TITLE
[7.67.x-blue]Update plexus utils version to 3.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
     <version.google.maps>0.9.0</version.google.maps>
     <version.okta>1.3.0</version.okta>
     <version.docker-java>3.4.2</version.docker-java>
+    <version.plexus.utils>3.6.1</version.plexus.utils>
     <!-- OSGI tests properties -->
     <version.org.apache.karaf>4.2.0</version.org.apache.karaf>
     <version.org.ops4j.pax.exam>4.13.4</version.org.ops4j.pax.exam>
@@ -149,6 +150,11 @@
         <groupId>org.jbpm</groupId>
         <artifactId>jbpm-executor</artifactId>
         <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>${version.plexus.utils}</version>
       </dependency>
       <dependency>
         <groupId>org.jbpm</groupId>


### PR DESCRIPTION
Updating plexus utils version to 3.6.1 resolves the [CVE-2025-67030]
Linked PRs :
https://github.com/kiegroup/kie-jpmml-integration/pull/96
https://github.com/kiegroup/kie-wb-distributions/pull/1251
https://github.com/kiegroup/kie-wb-common/pull/3848
https://github.com/kiegroup/drools-wb/pull/1578
https://github.com/kiegroup/process-migration-service/pull/145